### PR TITLE
v1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PhyloNetworks"
 uuid = "33ad39ac-ed31-50eb-9b15-43d0656eaa72"
 license = "MIT"
-version = "0.17.1"
+version = "1.0.0"
 
 [deps]
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"

--- a/Project.toml
+++ b/Project.toml
@@ -24,18 +24,19 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-BioSequences = "2.0, 3"
-BioSymbols = "4.0, 5"
+BioSequences = "2, 3"
+BioSymbols = "4, 5"
 CSV = "0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10"
-Combinatorics = "0.7, 1.0"
+Combinatorics = "0.7, 1"
 DataFrames = "1.3"
 DataStructures = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18"
 Distributions = "0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 FASTX = "1.1, 2"
 Functors = "0.2, 0.3, 0.4, 0.5"
 NLopt = "0.5.1, 0.6, 1"
+StaticArrays = "0.8.3, 0.9, 0.10, 0.11, 0.12, 1"
 StatsBase = "0.26, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33, 0.34"
-julia = "1.5, 1.6, 1.7"
+julia = "1.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PhyloNetworks"
 uuid = "33ad39ac-ed31-50eb-9b15-43d0656eaa72"
 license = "MIT"
-version = "0.17.0"
+version = "0.17.1"
 
 [deps]
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLopt = "76087f3c-5699-56af-9a33-bf431cd00edd"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter
 
 # this installs the dev version of PhyloPlots for compatibility.
 using Pkg
-Pkg.add(PackageSpec(name="PhyloPlots", rev="master"))
+Pkg.add(PackageSpec(name="PhyloPlots", rev="dev")) # change back to master...
 
 
 using PhyloNetworks

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter
 
 # this installs the dev version of PhyloPlots for compatibility.
 using Pkg
-Pkg.add(PackageSpec(name="PhyloPlots", rev="dev")) # change back to master...
+Pkg.add(PackageSpec(name="PhyloPlots", rev="master"))
 
 
 using PhyloNetworks

--- a/src/PhyloNetworks.jl
+++ b/src/PhyloNetworks.jl
@@ -22,6 +22,7 @@ module PhyloNetworks
     using DataFrames # innerjoin new in v0.21
     using DataStructures # for updateInCycle with priority queue
     using Distributions #for RateVariationAcrossSites
+    using StaticArrays # for quartets
     using FASTX
     using Functors: fmap
     using NLopt # for branch lengths optimization
@@ -122,7 +123,10 @@ module PhyloNetworks
         #maxParsimonyNet # broken after v0.17 refactoring: fix network search
         readfastatodna,
         # neighbor joining
-        nj
+        nj,
+        # quartets 
+        writeTableCF,
+        countquartetsintrees
 
     ##Constants
     const fAbsBL = 1e-10
@@ -148,5 +152,6 @@ module PhyloNetworks
     include("graph_components.jl")
     include("deprecated.jl")
     include("nj.jl")
+    include("quartets.jl")
 
 end #module

--- a/src/PhyloNetworks.jl
+++ b/src/PhyloNetworks.jl
@@ -124,7 +124,7 @@ module PhyloNetworks
         readfastatodna,
         # neighbor joining
         nj,
-        # quartets 
+        # quartets
         tablequartetCF,
         countquartetsintrees
 

--- a/src/PhyloNetworks.jl
+++ b/src/PhyloNetworks.jl
@@ -125,7 +125,7 @@ module PhyloNetworks
         # neighbor joining
         nj,
         # quartets 
-        writeTableCF,
+        tablequartetCF,
         countquartetsintrees
 
     ##Constants

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -572,7 +572,7 @@ level-1, with valid internal fields `e.inte1` (to track which cycle
 function deleteEdge!(net::HybridNetwork, e::Edge; part::Bool=true)
     if part
         if e.inte1 == -1 && !e.hybrid && !isempty(net.partition) && !isTree(net)
-            ind = whichPartition(net,e)
+            ind = whichpartition(net,e)
             indE = getIndex(e,net.partition[ind].edges)
             deleteat!(net.partition[ind].edges,indE)
         end
@@ -1460,14 +1460,14 @@ end
 # better to return the index than the partition itself, because we need the index
 # to use splice and delete it from net.partition later on
 # cycle: is the number to look for partition on that cycle only
-function whichPartition(net::HybridNetwork,edge::Edge,cycle::Integer)
+function whichpartition(net::HybridNetwork, edge::Edge, cycle::Integer)
     !edge.hybrid || error("edge $(edge.number) is hybrid so it cannot be in any partition")
     edge.inte1 == -1 || error("edge $(edge.number) is in cycle $(edge.inte1) so it cannot be in any partition")
     @debug "search partition for edge $(edge.number) in cycle $(cycle)"
     in(edge,net.edge) || error("edge $(edge.number) is not in net.edge")
     for i in 1:length(net.partition)
         @debug "looking for edge $(edge.number) in partition $(i): $([e.number for e in net.partition[i].edges])"
-        if(in(cycle,net.partition[i].cycle))
+        if in(cycle, net.partition[i].cycle)
             @debug "looking for edge $(edge.number) in partition $(i), with cycle $(cycle): $([e.number for e in net.partition[i].edges])"
             if in(edge,net.partition[i].edges)
                 @debug "partition for edge $(edge.number) is $([e.number for e in net.partition[i].edges])"
@@ -1475,7 +1475,7 @@ function whichPartition(net::HybridNetwork,edge::Edge,cycle::Integer)
             end
         end
     end
-    @debug begin; printPartitions(net); "" end
+    @debug begin; printpartitions(net); "" end
     error("edge $(edge.number) is not hybrid, nor part of any cycle, and it is not in any partition")
 end
 
@@ -1483,27 +1483,27 @@ end
 # returns the index of the partition, or error if not found
 # better to return the index than the partition itself, because we need the index
 # to use splice and delete it from net.partition later on
-function whichPartition(net::HybridNetwork,edge::Edge)
+function whichpartition(net::HybridNetwork, edge::Edge)
     !edge.hybrid || error("edge $(edge.number) is hybrid so it cannot be in any partition")
     edge.inte1 == -1 || error("edge $(edge.number) is in cycle $(edge.inte1) so it cannot be in any partition")
     @debug "search partition for edge $(edge.number) without knowing its cycle"
     in(edge,net.edge) || error("edge $(edge.number) is not in net.edge")
     for i in 1:length(net.partition)
         @debug "looking for edge $(edge.number) in partition $(i): $([e.number for e in net.partition[i].edges])"
-        if(in(edge,net.partition[i].edges))
+        if in(edge,net.partition[i].edges)
             @debug "partition for edge $(edge.number) is $([e.number for e in net.partition[i].edges])"
             return i
         end
     end
-    @debug begin printPartitions(net); "printed partitions" end
+    @debug begin printpartitions(net); "printed partitions" end
     error("edge $(edge.number) is not hybrid, nor part of any cycle, and it is not in any partition")
 end
 
-# function that will print the partition of net
-function printPartitions(net::HybridNetwork)
-    println("partition.cycle\t partition.edges")
+printpartitions(x) = printpartitions(stdout::IO, x)
+function printpartitions(io::IO, net::HybridNetwork)
+    println(io, "partition.cycle\t partition.edges")
     for p in net.partition
-        println("$(p.cycle)\t\t $([e.number for e in p.edges])")
+        println(io, "$(p.cycle)\t\t $([e.number for e in p.edges])")
     end
 end
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -6,28 +6,7 @@
 @deprecate readBootstrapTrees readmultinewick_files
 @deprecate writeTopology      writenewick
 @deprecate writeMultiTopology writemultinewick
-v16msg = """
-    To roll back to PhyloNetworks v0.16, do this after typing ] to get into package mode:
-    pkg> add PhyloNetworks#v0.16.4
-    Then, also pin PhyloPlots to version v1.0.1:
-    pkg> add PhyloPlots#v1.0.1
-    See here for help about adding packages and checking versions:
-    https://pkgdocs.julialang.org/v1/managing-packages/#Adding-packages
-    """
-@deprecate writeTableCF(obj...; kwargs...) writeTableCF()
-writeTableCF() =
-    error("""writeTableCF works with PhyloNetworks v0.16.
-    Starting with PhyloNetworks v1 (and SNaQ v1), please use instead
-    tablequartetCF(quartetlist::Vector{QuartetT} [, taxonnames];...)
-    The resulting named tuple can be converted to a data frame like so for example:
-    DataFrame(tablequartetCF(...), copycols=false)
-    """ * "\n" * v16msg)
-@deprecate snaq!(obj...; kwargs...) snaq!()
-snaq!() =
-    error("""snaq! was moved from PhyloNetworks.jl to SNaQ.jl. To use it, do this:
-    pkg> add SNaQ
-    Otherwise, snaq! is available in PhyloNetworks v0.16.
-    """ * "\n" * v16msg)
+Base.@deprecate_moved snaq! "SNaQ"
 # minor name changes: camelCase to smallcase
 @deprecate printEdges printedges
 @deprecate printNodes printnodes

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -6,6 +6,28 @@
 @deprecate readBootstrapTrees readmultinewick_files
 @deprecate writeTopology      writenewick
 @deprecate writeMultiTopology writemultinewick
+v16msg = """
+    To roll back to PhyloNetworks v0.16, do this after typing ] to get into package mode:
+    pkg> add PhyloNetworks#v0.16.4
+    Then, also pin PhyloPlots to version v1.0.1:
+    pkg> add PhyloPlots#v1.0.1
+    See here for help about adding packages and checking versions:
+    https://pkgdocs.julialang.org/v1/managing-packages/#Adding-packages
+    """
+@deprecate writeTableCF(obj...; kwargs...) writeTableCF()
+writeTableCF() =
+    error("""writeTableCF works with PhyloNetworks v0.16.
+    Starting with PhyloNetworks v1 (and SNaQ v1), please use instead
+    tablequartetCF(quartetlist::Vector{QuartetT} [, taxonnames];...)
+    The resulting named tuple can be converted to a data frame like so for example:
+    DataFrame(tablequartetCF(...), copycols=false)
+    """ * "\n" * v16msg)
+@deprecate snaq!(obj...; kwargs...) snaq!()
+snaq!() =
+    error("""snaq! was moved from PhyloNetworks.jl to SNaQ.jl. To use it, do this:
+    pkg> add SNaQ
+    Otherwise, snaq! is available in PhyloNetworks v0.16.
+    """ * "\n" * v16msg)
 # minor name changes: camelCase to smallcase
 @deprecate printEdges printedges
 @deprecate printNodes printnodes

--- a/src/descriptive.jl
+++ b/src/descriptive.jl
@@ -15,7 +15,7 @@ function tiplabels(net::HybridNetwork)
 end
 
 # extract & sort the union of taxa of list of gene trees
-function uniontaxa(trees::Vector{HybridNetwork})
+function tiplabels(trees::Vector{HybridNetwork})
     taxa = reduce(union, tiplabels(t) for t in trees)
     return sort_stringasinteger!(taxa)
 end

--- a/src/descriptive.jl
+++ b/src/descriptive.jl
@@ -14,9 +14,30 @@ function tiplabels(net::HybridNetwork)
     return String[l.name for l in net.leaf] # AbstractString does not work for use by tree2Matrix
 end
 
-# function that we need to overwrite to avoid printing useless scary
-# output for HybridNetworks
-# PROBLEM: writenewick changes the network and thus show changes the network
+# extract & sort the union of taxa of list of gene trees
+function uniontaxa(trees::Vector{HybridNetwork})
+    taxa = reduce(union, tiplabels(t) for t in trees)
+    return sort_stringasinteger!(taxa)
+end
+
+"""
+    sort_stringasinteger!(taxa)
+
+Sort a vector of strings `taxa`, numerically if
+elements can be parsed as an integer, alphabetically otherwise.
+"""
+function sort_stringasinteger!(taxa)
+    sortby = x->parse(Int,x)
+    try
+        parse.(Int,taxa)
+    catch
+        sortby = identity
+    end
+    sort!(taxa, by=sortby)
+    return taxa
+end
+
+# 'show' should not (and does not) modify the object
 function Base.show(io::IO, obj::HybridNetwork)
     disp = "$(typeof(obj)), "
     if obj.isrooted
@@ -39,7 +60,10 @@ function Base.show(io::IO, obj::HybridNetwork)
     end
     par = ""
     try
-        # par = writenewick(obj,round=true) # but writenewick changes the network, not good
+        #= *not* 'writenewick(obj,round=true)' because writenewick changes
+        the network (runs directedges! and if it fails, tries other rootings).
+        writesubtree! does *not* modify the network.
+        =#
         s = IOBuffer()
         writesubtree!(s, obj, false,true, true,3,true)
         par = String(take!(s))
@@ -52,8 +76,6 @@ function Base.show(io::IO, obj::HybridNetwork)
     disp *= "\n$par"
     println(io, disp)
 end
-
-
 
 function Base.show(io::IO, obj::Node)
     disp = "$(typeof(obj)):"

--- a/src/quartets.jl
+++ b/src/quartets.jl
@@ -92,6 +92,7 @@ See [`countquartetsintrees`](@ref) for examples.
 function tablequartetCF(
     quartets::Vector{QuartetT{T}},
     taxa::AbstractVector{<:AbstractString}=Vector{String}();
+    removeQwithoutgenes::Bool=true,
     colnames=nothing
 ) where T <: Union{StaticVector{3}, StaticVector{4}, StaticMatrix{3,N} where N}
     V = eltype(T)
@@ -117,7 +118,7 @@ function tablequartetCF(
     for _ in eachindex(colnames_data) push!(tuplevecs, V[]); end
     nt = (; zip(tuplenames,tuplevecs)...) # no copy
     indngenes = findfirst(isequal(:ngenes), tupledat)
-    hasngenes = !isnothing(indngenes)
+    hasngenes = removeQwithoutgenes && !isnothing(indngenes)
     for q in quartets
         hasngenes && q.data[indngenes] == 0 && continue # skip quartets with 0 genes
         push!(nt[:qind], q.number)
@@ -247,7 +248,7 @@ data: [1.0, 0.0, 0.0, 0.5]
 ```
 
 ```jldoctest quartet
-julia> nt = tablequartetCF(q,t); # named tuple. can be saved to a file later
+julia> nt = tablequartetCF(q,t; removeQwithoutgenes=false); # named tuple. can be saved to a file later
 
 julia> df = DataFrame(nt, copycols=false); # convert to a data frame, without copying the column data
 
@@ -271,7 +272,7 @@ Reading in trees, looking at 5 quartets in each...
 0+--+100%
   **
 
-julia> show(DataFrame(tablequartetCF(q,t), copycols=false), allcols=true)
+julia> show(DataFrame(tablequartetCF(q,t), copycols=false), allcols=true) # qind=5 excluded: 0 genes
 5×9 DataFrame
  Row │ qind   t1      t2      t3      t4      CF12_34   CF13_24   CF14_23   ngenes  
      │ Int64  String  String  String  String  Float64   Float64   Float64   Float64 
@@ -280,7 +281,6 @@ julia> show(DataFrame(tablequartetCF(q,t), copycols=false), allcols=true)
    2 │     2  A       B       D       O       0.5       0.5       0.0           2.0
    3 │     3  A       B       E       O       1.0       0.0       0.0           1.0
    4 │     4  A       D       E       O       1.0       0.0       0.0           1.0
-   5 │     5  B       D       E       O       0.0       0.0       0.0           0.0
 ```
 """
 function countquartetsintrees(

--- a/src/quartets.jl
+++ b/src/quartets.jl
@@ -142,33 +142,6 @@ end
 
 
 
-
-# ---------------- read input gene trees and calculate obsCF ----------------------
-
-
-
-
-
-"""
-    sort_stringasinteger!(taxa)
-
-Sort a vector of strings `taxa`, numerically if
-elements can be parsed as an integer, alphabetically otherwise.
-"""
-function sort_stringasinteger!(taxa)
-    sortby = x->parse(Int,x)
-    try
-        parse.(Int,taxa)
-    catch
-        sortby = identity
-    end
-    sort!(taxa, by=sortby)
-    return taxa
-end
-
-
-
-
 """
     countquartetsintrees(trees [, taxonmap]; which=:all, weight_byallele=true)
 
@@ -442,30 +415,4 @@ function quartetRankResolution(t1::Int, t2::Int, t3::Int, t4::Int, nCk::Matrix)
         end
     end
     return rank, resolution
-end
-
-
-
-# extract & sort the union of taxa of list of gene trees
-function uniontaxa(trees::Vector{HybridNetwork})
-    taxa = reduce(union, tiplabels(t) for t in trees)
-    return sort_stringasinteger!(taxa)
-end
-
-
-"""
-    sort_stringasinteger!(taxa)
-
-Sort a vector of strings `taxa`, numerically if
-elements can be parsed as an integer, alphabetically otherwise.
-"""
-function sort_stringasinteger!(taxa)
-    sortby = x->parse(Int,x)
-    try
-        parse.(Int,taxa)
-    catch
-        sortby = identity
-    end
-    sort!(taxa, by=sortby)
-    return taxa
 end

--- a/src/quartets.jl
+++ b/src/quartets.jl
@@ -267,7 +267,7 @@ function countquartetsintrees(tree::Vector{HybridNetwork},
                            showprogressbar::Bool=true)
     whichQ in [:all, :intrees] || error("whichQ must be either :all or :intrees, but got $whichQ")
     if isempty(taxonmap)
-        taxa = tipLabels(tree)
+        taxa = tiplabels(tree)
     else
         taxa = sort!(collect(Set(haskey(taxonmap, l.name) ? taxonmap[l.name] : l.name
                                  for t in tree for l in t.leaf)))

--- a/src/quartets.jl
+++ b/src/quartets.jl
@@ -63,7 +63,7 @@ end
 
 
 """
-    writeTableCF(quartetlist::Vector{QuartetT} [, taxonnames]; colnames)
+    tablequartetCF(quartetlist::Vector{QuartetT} [, taxonnames]; colnames)
 
 Convert a vector of [`QuartetT`](@ref) objects to a data frame, with 1 row for
 each four-taxon set in the list. Each four-taxon set contains quartet data of
@@ -82,7 +82,7 @@ In the output data frame, the columns are, in this order:
   For the data frame to have non-default column names, provide the desired
   3, 4, or 3×n names as a vector via the optional argument `colnames`.
 """
-function writeTableCF(quartets::Vector{QuartetT{T}},
+function tablequartetCF(quartets::Vector{QuartetT{T}},
             taxa::AbstractVector{<:AbstractString}=Vector{String}();
             colnames=nothing) where
             T <: Union{StaticVector{3}, StaticVector{4}, StaticMatrix{3,N} where N}
@@ -122,7 +122,7 @@ If T is a length-4 vector type, the 4th name is "ngenes".
 If T is a 3×n matrix type, the output vector contains 3×n names,
 3 for each of "CF", "V2_", "V3_", ... "Vn_".
 
-Used by [`writeTableCF`](@ref) to build a data frame from a vector of
+Used by [`tablequartetCF`](@ref) to build a data frame from a vector of
 [`QuartetT`](@ref) objects.
 """
 function quartetdata_columnnames(::Type{T}) where T <: StaticArray{Tuple{3},S,1} where S
@@ -174,7 +174,7 @@ end
 
 Calculate the quartet concordance factors (CF) observed in the `trees` vector.
 If present, `taxonmap` should be a dictionary that maps each allele name to it's species name.
-To save to a file, first convert to a data frame using [`writeTableCF`](@ref).
+To save to a file, first convert to a data frame using [`tablequartetCF`](@ref).
 When `which=:all`, quartet CFs are calculated for all 4-taxon sets.
 (Other options are not implemented yet.)
 
@@ -254,7 +254,7 @@ data: [1.0, 0.0, 0.0, 0.5]
 ```
 
 ```jldoctest quartet
-julia> df = writeTableCF(q,t); # to get a DataFrame that can be saved to a file later
+julia> df = tablequartetCF(q,t); # to get a DataFrame that can be saved to a file later
 
 julia> show(df, allcols=true)
 5×9 DataFrame
@@ -276,7 +276,7 @@ Reading in trees, looking at 5 quartets in each...
 0+--+100%
   **
 
-julia> show(writeTableCF(q,t), allcols=true)
+julia> show(tablequartetCF(q,t), allcols=true)
 5×9 DataFrame
  Row │ qind   t1      t2      t3      t4      CF12_34   CF13_24   CF14_23   ngenes  
      │ Int64  String  String  String  String  Float64   Float64   Float64   Float64 

--- a/src/quartets.jl
+++ b/src/quartets.jl
@@ -1,0 +1,471 @@
+
+"""
+    quartetrank(t1,t2,t3,t4, nCk::Matrix)
+    quartetrank([t1,t2,t3,t4], nCk)
+
+Return the rank of a four-taxon set with taxon numbers `t1,t2,t3,t4`,
+assuming that `ti`s are positive integers such that t1<t2, t2<t3 and t3<t4
+(assumptions not checked!).
+`nCk` should be a matrix of "n choose k" binomial coefficients:
+see [`nchoose1234`](@ref).
+
+# examples
+
+```jldoctest
+julia> nCk = PhyloNetworks.nchoose1234(5)
+6×4 Matrix{Int64}:
+ 0   0   0  0
+ 1   0   0  0
+ 2   1   0  0
+ 3   3   1  0
+ 4   6   4  1
+ 5  10  10  5
+
+julia> PhyloNetworks.quartetrank([1,2,3,4], nCk)
+1
+
+julia> PhyloNetworks.quartetrank([3,4,5,6], nCk)
+15
+```
+"""
+@inline function quartetrank(tnum::AbstractVector, nCk::Matrix)
+    quartetrank(tnum..., nCk)
+end
+@inline function quartetrank(t1::Int, t2::Int, t3::Int, t4::Int, nCk::Matrix)
+    # rank-1 = t1-1 choose 1 + t2-1 choose 2 + t3-1 choose 3 + t4-1 choose 4
+    return nCk[t1,1] + nCk[t2,2] + nCk[t3,3] + nCk[t4,4] + 1
+end
+
+
+"""
+    nchoose1234(nmax)
+
+`nmax+1 x 4` matrix containing the binomial coefficient
+"n choose k" in row `n+1` and column `k`. In other words,
+`M[i,k]` gives "i-1 choose k". It is useful to store these
+values and look them up to rank (a large number of) 4-taxon sets:
+see [`quartetrank`](@ref).
+"""
+function nchoose1234(nmax::Int)
+    # compute nC1, nC2, nC3, nC4 for n in [0, nmax]: used for ranking quartets
+    M = Matrix{Int}(undef, nmax+1, 4)
+    for i in 1:(nmax+1)
+        M[i,1] = i-1 # n choose 1 = n. row i is for n=i-1
+    end
+    M[1,2:4] .= 0 # 0 choose 2,3,4 = 0
+    for i in 2:(nmax+1)
+        for k in 2:4 # to choose k items in 1..n: the largest could be n, else <= n-1
+            M[i,k] = M[i-1,k-1] + M[i-1,k]
+        end
+    end
+    return M
+end
+
+
+"""
+    writeTableCF(quartetlist::Vector{QuartetT} [, taxonnames]; colnames)
+
+Convert a vector of [`QuartetT`](@ref) objects to a data frame, with 1 row for
+each four-taxon set in the list. Each four-taxon set contains quartet data of
+some type `T`, which determines the number of columns in the data frame.
+This data type `T` should be a vector of length 3 or 4, or a 3×n matrix.
+
+In the output data frame, the columns are, in this order:
+- `qind`: contains the quartet's `number`
+- `t1, t2, t3, t4`: contain the quartet's `taxonnumber`s if no `taxonnames`
+  are given, or the taxon names otherwise. The name of taxon number `i` is
+  taken to be `taxonnames[i]`.
+- 3 columns for each column in the quartet's `data`.
+  The first 3 columns are named `CF12_34, CF13_24, CF14_23`. The next
+  columns are named `V2_12_34, V2_13_24, V2_14_23` and contain the data in
+  the second column of the quartet's data matrix. And so on.
+  For the data frame to have non-default column names, provide the desired
+  3, 4, or 3×n names as a vector via the optional argument `colnames`.
+"""
+function writeTableCF(quartets::Vector{QuartetT{T}},
+            taxa::AbstractVector{<:AbstractString}=Vector{String}();
+            colnames=nothing) where
+            T <: Union{StaticVector{3}, StaticVector{4}, StaticMatrix{3,N} where N}
+    V = eltype(T)
+    colnames_data = quartetdata_columnnames(T)
+    if !isnothing(colnames)
+        if length(colnames) == length(colnames_data)
+            colnames_data = colnames
+        else
+          @error "'colnames' needs to be of length $(length(colnames_data)).\nwill use default column names."
+        end
+    end
+    translate = !isempty(taxa)
+    tnT = (translate ? eltype(taxa) : Int) # Type for taxon names
+    if translate
+        taxstring = x -> taxa[x] # will error if a taxonnumber > length(taxa): okay
+    else
+        taxstring = x -> x
+    end
+    df = DataFrames.DataFrame(qind=Int[], t1=tnT[],t2=tnT[],t3=tnT[],t4=tnT[])
+    for cn in colnames_data
+        df[:,Symbol(cn)] = V[]
+    end
+    for q in quartets
+      push!(df, (q.number, taxstring.(q.taxonnumber)..., q.data...) )
+    end
+    return df
+end
+
+
+"""
+    quartetdata_columnnames(T) where T <: StaticArray
+
+Vector of column names to hold the quartet data of type `T` in a data frame.
+If T is a length-3 vector type, they are "CF12_34","CF13_24","CF14_23".
+If T is a length-4 vector type, the 4th name is "ngenes".
+If T is a 3×n matrix type, the output vector contains 3×n names,
+3 for each of "CF", "V2_", "V3_", ... "Vn_".
+
+Used by [`writeTableCF`](@ref) to build a data frame from a vector of
+[`QuartetT`](@ref) objects.
+"""
+function quartetdata_columnnames(::Type{T}) where T <: StaticArray{Tuple{3},S,1} where S
+    return ["CF12_34","CF13_24","CF14_23"]
+end
+function quartetdata_columnnames(::Type{T}) where T <: StaticArray{Tuple{4},S,1} where S
+    return ["CF12_34","CF13_24","CF14_23","ngenes"]
+end
+function quartetdata_columnnames(::Type{T}) where # for a 3×N matrix: N names
+                T <: StaticArray{Tuple{3,N},S,2} where {N,S}
+    N > 0 || error("expected at least 1 column of data")
+    colnames_q = ["12_34","13_24","14_23"]
+    colnames = "CF" .* colnames_q
+    for i in 2:N append!(colnames, "V$(i)_" .* colnames_q); end
+    return colnames
+end
+
+
+
+
+# ---------------- read input gene trees and calculate obsCF ----------------------
+
+
+
+
+
+"""
+    sort_stringasinteger!(taxa)
+
+Sort a vector of strings `taxa`, numerically if
+elements can be parsed as an integer, alphabetically otherwise.
+"""
+function sort_stringasinteger!(taxa)
+    sortby = x->parse(Int,x)
+    try
+        parse.(Int,taxa)
+    catch
+        sortby = identity
+    end
+    sort!(taxa, by=sortby)
+    return taxa
+end
+
+
+
+
+"""
+    countquartetsintrees(trees [, taxonmap]; which=:all, weight_byallele=true)
+
+Calculate the quartet concordance factors (CF) observed in the `trees` vector.
+If present, `taxonmap` should be a dictionary that maps each allele name to it's species name.
+To save to a file, first convert to a data frame using [`writeTableCF`](@ref).
+When `which=:all`, quartet CFs are calculated for all 4-taxon sets.
+(Other options are not implemented yet.)
+
+The algorithm runs in O(mn⁴) where m is the number of trees and n is the number
+of tips in the trees.
+
+CFs are calculated at the species level only, that is, considering 4-taxon sets
+made of 4 distinct species, even if the gene trees may have multiple alleles
+from the same species. For 4 distinct species `a,b,c,d`, all alleles from
+each species (`a` etc.) will be considered to calculate the quartet CF.
+
+By default, each gene has a weight of 1. So if there are `n_a` alleles from `a`,
+`n_b` alleles from `b` etc. in a given gene, then each set of 4 alleles has a
+weight of `1/(n_a n_b b_c n_c)` in the calculation of the CF for `a,b,c,d`.
+With option `weight_byallele=true`, then each set of 4 alleles is given a
+weight of 1 instead. This inflates the total number of sets used to calculate
+the quartet CFs (to something larger than the number of genes). This may also
+affect the CF values if the number of alleles varies across genes: genes with
+more alleles will be given more weight.
+
+# examples
+```jldoctest quartet
+julia> tree1 = readnewick("(E,(A,B),(C,D),O);"); tree2 = readnewick("(((A,B),(C,D)),E);");
+
+julia> q,t = countquartetsintrees([tree1, tree2]);
+Reading in trees, looking at 15 quartets in each...
+0+--+100%
+  **
+
+julia> t # taxon order: t[i] = name of taxon number i
+6-element Vector{String}:
+ "A"
+ "B"
+ "C"
+ "D"
+ "E"
+ "O"
+
+julia> length(q) # 15 four-taxon sets on 6 taxa
+15
+
+julia> q[1] # both trees agree on AB|CD: resolution 1
+4-taxon set number 1; taxon numbers: 1,2,3,4
+data: [1.0, 0.0, 0.0, 2.0]
+
+julia> q[8] # tree 2 is missing O (taxon 6), tree 1 wants resolution 3: AO|CD
+4-taxon set number 8; taxon numbers: 1,3,4,6
+data: [0.0, 0.0, 1.0, 1.0]
+
+julia> q[11] # tree 1 has ACEO unresolved, and tree 2 is missing O: no data for this quartet
+4-taxon set number 11; taxon numbers: 1,3,5,6
+data: [0.0, 0.0, 0.0, 0.0]
+
+julia> tree1 = readnewick("(E,(a1,B),(a2,D),O);"); tree2 = readnewick("(((a1,a2),(B,D)),E);");
+
+julia> q,t = countquartetsintrees([tree1, tree2], Dict("a1"=>"A", "a2"=>"A"); showprogressbar=false);
+
+julia> t
+5-element Vector{String}:
+ "A"
+ "B"
+ "D"
+ "E"
+ "O"
+
+```
+
+
+```jldoctest quartet
+julia> q[1] # tree 1 has discordance: a1B|DE and a2D|BE. tree 2 has AE|BD for both alleles of A
+4-taxon set number 1; taxon numbers: 1,2,3,4
+data: [0.25, 0.25, 0.5, 2.0]
+
+julia> q[3] # tree 2 is missing O (taxon 5), and a2 is unresolved in tree 1. There's only a1B|EO
+4-taxon set number 3; taxon numbers: 1,2,4,5
+data: [1.0, 0.0, 0.0, 0.5]
+```
+
+```jldoctest quartet
+julia> df = writeTableCF(q,t); # to get a DataFrame that can be saved to a file later
+
+julia> show(df, allcols=true)
+5×9 DataFrame
+ Row │ qind   t1      t2      t3      t4      CF12_34  CF13_24  CF14_23  ngenes  
+     │ Int64  String  String  String  String  Float64  Float64  Float64  Float64 
+─────┼───────────────────────────────────────────────────────────────────────────
+   1 │     1  A       B       D       E          0.25     0.25      0.5      2.0
+   2 │     2  A       B       D       O          0.5      0.5       0.0      1.0
+   3 │     3  A       B       E       O          1.0      0.0       0.0      0.5
+   4 │     4  A       D       E       O          1.0      0.0       0.0      0.5
+   5 │     5  B       D       E       O          0.0      0.0       0.0      0.0
+
+julia> # using CSV; CSV.write(df, "filename.csv");
+
+julia> tree2 = readnewick("((A,(B,D)),E);");
+
+julia> q,t = countquartetsintrees([tree1, tree2], Dict("a1"=>"A", "a2"=>"A"); weight_byallele=true);
+Reading in trees, looking at 5 quartets in each...
+0+--+100%
+  **
+
+julia> show(writeTableCF(q,t), allcols=true)
+5×9 DataFrame
+ Row │ qind   t1      t2      t3      t4      CF12_34   CF13_24   CF14_23   ngenes  
+     │ Int64  String  String  String  String  Float64   Float64   Float64   Float64 
+─────┼──────────────────────────────────────────────────────────────────────────────
+   1 │     1  A       B       D       E       0.333333  0.333333  0.333333      3.0
+   2 │     2  A       B       D       O       0.5       0.5       0.0           2.0
+   3 │     3  A       B       E       O       1.0       0.0       0.0           1.0
+   4 │     4  A       D       E       O       1.0       0.0       0.0           1.0
+   5 │     5  B       D       E       O       0.0       0.0       0.0           0.0
+```
+"""
+function countquartetsintrees(tree::Vector{HybridNetwork},
+                           taxonmap::Dict=Dict{String,String}();
+                           whichQ::Symbol=:all, weight_byallele::Bool=false,
+                           showprogressbar::Bool=true)
+    whichQ in [:all, :intrees] || error("whichQ must be either :all or :intrees, but got $whichQ")
+    if isempty(taxonmap)
+        taxa = unionTaxa(tree)
+    else
+        taxa = sort!(collect(Set(haskey(taxonmap, l.name) ? taxonmap[l.name] : l.name
+                                 for t in tree for l in t.leaf)))
+    end
+    taxonnumber = Dict(taxa[i] => i for i in eachindex(taxa))
+    ntax = length(taxa)
+    nCk = nchoose1234(ntax) # matrix used to ranks 4-taxon sets
+    qtype = MVector{4,Float64} # 4 floats: CF12_34, CF13_24, CF14_23, ngenes; initialized at 0.0
+    if whichQ == :all
+        numq = nCk[ntax+1,4]
+        quartet = Vector{QuartetT{qtype}}(undef, numq)
+        ts = [1,2,3,4]
+        for qi in 1:numq
+            quartet[qi] = QuartetT(qi, SVector{4}(ts), MVector(0.,0.,0.,0.))
+            # next: find the 4-taxon set with the next rank,
+            #       faster than using the direct mapping function
+            ind = findfirst(x -> x>1, diff(ts))
+            if ind === nothing ind = 4; end
+            ts[ind] += 1
+            for j in 1:(ind-1)
+                ts[j] = j
+            end
+        end
+    else
+        error("whichQ = :intrees not implemented yet")
+        # fixit: read all the trees, go through each edge, check if the current quartet list covers the edge, if not: add a quartet
+    end
+    totalt = length(tree)
+    if showprogressbar
+        nstars = (totalt < 50 ? totalt : 50)
+        ntrees_perstar = (totalt/nstars)
+        println("Reading in trees, looking at $numq quartets in each...")
+        print("0+" * "-"^nstars * "+100%\n  ")
+        stars = 0
+        nextstar = Integer(ceil(ntrees_perstar))
+    end
+    for i in 1:totalt # number of times each quartet resolution is seen in each tree
+        countquartetsintrees!(quartet, tree[i], whichQ, weight_byallele, nCk, taxonnumber, taxonmap)
+        if showprogressbar && i >= nextstar
+            print("*")
+            stars += 1
+            nextstar = Integer(ceil((stars+1) * ntrees_perstar))
+        end
+    end
+    showprogressbar && print("\n")
+    # normalize counts to frequencies & number of genes
+    for q in quartet
+        d = q.data
+        d[4] = d[1]+d[2]+d[3] # number of genes
+        if d[4] > 0.0
+            d[1:3] /= d[4]
+        end # otherwise: no genes with data on this quartet (missing taxa or polytomy): leave all zeros (NaN if /0)
+    end
+    return quartet, taxa
+end
+function countquartetsintrees!(quartet::Vector{QuartetT{MVector{4,Float64}}},
+            tree::HybridNetwork, whichQ::Symbol, weight_byallele::Bool, nCk::Matrix,
+            taxonnumber::Dict{<:AbstractString,Int}, taxonmap::Dict{<:AbstractString,<:AbstractString})
+    tree.numhybrids == 0 || error("input phylogenies must be trees")
+    # next: reset node & edge numbers so that they can be used as indices: 1,2,3,...
+    resetnodenumbers!(tree; checkpreorder=true, type=:postorder) # leaves first & post-order
+    resetedgenumbers!(tree)
+    # next: build list leaf number -> species ID, using the node name then taxon map
+    nleaves = length(tree.leaf)
+    nnodes  = length(tree.node)
+    taxID = Vector{Int}(undef, nleaves)
+    for n in tree.leaf
+        taxID[n.number] = haskey(taxonmap, n.name) ? taxonnumber[taxonmap[n.name]] : taxonnumber[n.name]
+    end
+    # number of individuals from each species: needed to weigh the quartets at the individual level
+    # weight of t1,t2,t3,t4: 1/(taxcount[t1]*taxcount[t2]*taxcount[t3]*taxcount[t4])
+    taxcount = zeros(Int, length(taxonnumber))
+    for ti in taxID taxcount[ti] += 1; end
+    # next: build data structure to get descendant / ancestor clades
+    below,above = ladderpartition(tree) # re-checks that node numbers can be used as indices, with leaves first
+    # below[n][1:2 ]: left & clades below node number n
+    # above[n][1:end]: grade of clades above node n
+    for n in (nleaves+1):nnodes # loop through internal nodes indices only
+        bn = below[n]
+        an = above[n]
+        for c1 in 2:length(bn) # c = child clade, loop over all pairs of child clades
+          for t1 in bn[c1]     # pick 1 tip from each child clade
+            s1 = taxID[t1]
+            for c2 in 1:(c1-1)
+              for t2 in bn[c2]
+                s2 = taxID[t2]
+                s1 != s2 || continue # skip quartets that have repeated species
+                t12max = max(t1,t2)
+                leftweight = 1/(taxcount[s1]*taxcount[s2])
+                for p1 in 1:length(an) # p = parent clade
+                  for t3i in 1:length(an[p1])
+                    t3 = an[p1][t3i]
+                    s3 = taxID[t3]
+                    (s3 != s1 && s3 != s2) || continue
+                    for t4i in 1:(t3i-1) # pick 2 distinct tips from the same parent clade
+                        t4 = an[p1][t4i]
+                        t3 > t12max || t4 > t12max || continue   # skip: would be counted twice otherwise
+                        s4 = taxID[t4]
+                        (s4 != s1 && s4 != s2 && s4 != s3) || continue
+                        rank,res = quartetRankResolution(s1, s2, s3, s4, nCk)
+                        weight = ( weight_byallele ? 1.0 : leftweight / (taxcount[s3]*taxcount[s4]) )
+                        quartet[rank].data[res] += weight
+                    end
+                    for p2 in 1:(p1-1) # distinct parent clade: no risk of counting twice
+                      for t4 in an[p2]
+                        s4 = taxID[t4]
+                        (s4 != s1 && s4 != s2 && s4 != s3) || continue
+                        rank,res = quartetRankResolution(s1, s2, s3, s4, nCk)
+                        weight = ( weight_byallele ? 1.0 : leftweight / (taxcount[s3]*taxcount[s4]) )
+                        quartet[rank].data[res] += weight
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+    end
+end
+
+
+function quartetRankResolution(t1::Int, t2::Int, t3::Int, t4::Int, nCk::Matrix)
+    # quartet: t1 t2 | t3 t4, but indices have not yet been ordered: t1<t2, t3<t4, t1<min(t3,t4)
+    if t3 > t4 # make t3 smallest of t3, t4
+        (t3,t4) = (t4,t3)
+    end
+    if t1 > t2 # make t1 smallest of t1, t2
+        (t1,t2) = (t2,t1)
+    end
+    if t1 > t3 # swap t1 with t3, t2 with t4 - makes t1 smallest
+        (t1,t3) = (t3,t1)
+        (t2,t4) = (t4,t2)
+    end
+    if t2 < t3 # t2 2nd smallest: order t1 < t2 < t3 < t4
+        resolution = 1; # 12|34 after ordering indices
+        rank = quartetrank(t1, t2, t3, t4, nCk)
+    else # t3 2nd smallest
+        if t2 < t4 # order t1 < t3 < t2 < t4
+            resolution = 2; # 13|24 after ordering
+            rank = quartetrank(t1, t3, t2, t4, nCk);
+        else # order t1 < t3 < t4 < t2
+            resolution = 3; # 14|23 after ordering
+            rank = quartetrank(t1, t3, t4, t2, nCk);
+        end
+    end
+    return rank, resolution
+end
+
+
+
+# extract & sort the union of taxa of list of gene trees
+function unionTaxa(trees::Vector{HybridNetwork})
+    taxa = reduce(union, tiplabels(t) for t in trees)
+    return sort_stringasinteger!(taxa)
+end
+
+
+"""
+    sort_stringasinteger!(taxa)
+
+Sort a vector of strings `taxa`, numerically if
+elements can be parsed as an integer, alphabetically otherwise.
+"""
+function sort_stringasinteger!(taxa)
+    sortby = x->parse(Int,x)
+    try
+        parse.(Int,taxa)
+    catch
+        sortby = identity
+    end
+    sort!(taxa, by=sortby)
+    return taxa
+end

--- a/src/quartets.jl
+++ b/src/quartets.jl
@@ -294,7 +294,7 @@ function countquartetsintrees(tree::Vector{HybridNetwork},
                            showprogressbar::Bool=true)
     whichQ in [:all, :intrees] || error("whichQ must be either :all or :intrees, but got $whichQ")
     if isempty(taxonmap)
-        taxa = unionTaxa(tree)
+        taxa = uniontaxa(tree)
     else
         taxa = sort!(collect(Set(haskey(taxonmap, l.name) ? taxonmap[l.name] : l.name
                                  for t in tree for l in t.leaf)))

--- a/src/quartets.jl
+++ b/src/quartets.jl
@@ -267,7 +267,7 @@ function countquartetsintrees(tree::Vector{HybridNetwork},
                            showprogressbar::Bool=true)
     whichQ in [:all, :intrees] || error("whichQ must be either :all or :intrees, but got $whichQ")
     if isempty(taxonmap)
-        taxa = uniontaxa(tree)
+        taxa = tipLabels(tree)
     else
         taxa = sort!(collect(Set(haskey(taxonmap, l.name) ? taxonmap[l.name] : l.name
                                  for t in tree for l in t.leaf)))

--- a/src/quartets.jl
+++ b/src/quartets.jl
@@ -447,7 +447,7 @@ end
 
 
 # extract & sort the union of taxa of list of gene trees
-function unionTaxa(trees::Vector{HybridNetwork})
+function uniontaxa(trees::Vector{HybridNetwork})
     taxa = reduce(union, tiplabels(t) for t in trees)
     return sort_stringasinteger!(taxa)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Random
 using StableRNGs
 
 tests = [
+    "test_quartet.jl",
     "test_auxiliary.jl",
     "test_generatetopology.jl",
     "test_addHybrid.jl",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Random
 using StableRNGs
 
 tests = [
+    "test_deprecated.jl",
     "test_quartet.jl",
     "test_auxiliary.jl",
     "test_generatetopology.jl",

--- a/test/test_auxiliary.jl
+++ b/test/test_auxiliary.jl
@@ -201,6 +201,8 @@ ns = (@test_logs (:warn, r"won't erase with") (:warn, r"^skipped phylogeny on li
     joinpath(exdir,"test_reticulatetreeblock.nex")))
 @test length(ns) == 3
 @test tiplabels(ns[2]) == ["tax4","tax3","tax2","tax1"]
+@test tiplabels(ns) == ["tax1", "tax2", "tax3", "tax4", "tax5"]
+@test PhyloNetworks.sort_stringasinteger!(["1","10","2"]) == ["1","2","10"]
 # net with a hybrid leaf
 net = readnewick("((#H1:::0.1,b),c,#H1:::0.9);")
 PhyloNetworks.addChild!(net, net.node[1])

--- a/test/test_deprecated.jl
+++ b/test/test_deprecated.jl
@@ -1,0 +1,3 @@
+@testset "deprecated" begin
+@test_throws "snaq! has been moved to the package SNaQ.jl" snaq!()
+end

--- a/test/test_quartet.jl
+++ b/test/test_quartet.jl
@@ -39,7 +39,8 @@ qlist = [
   PN.QuartetT(2, SVector{4}(1,2,3,5), MVector{4,Int8}(0,0,1, 0)),
   PN.QuartetT(3, SVector{4}(1,2,4,5), MVector{4,Int8}(1,0,0, 5)),
 ]
-@test tablequartetCF(qlist) == (qind=[1,3],t1=[1,1],t2=[2,2],t3=[3,4], t4=[4,5],
+@test tablequartetCF(qlist; keepQwithoutgenes=false) ==
+  (qind=[1,3],t1=[1,1],t2=[2,2],t3=[3,4], t4=[4,5],
   CF12_34=[0,1],CF13_24=[1,0],CF14_23=[0,0], ngenes=[10,5])
 end
 

--- a/test/test_quartet.jl
+++ b/test/test_quartet.jl
@@ -17,20 +17,20 @@ qlist = [
   PN.QuartetT(1, SVector{4}(1,2,3,4), MVector{3,Bool}(0,1,0)),
   PN.QuartetT(2, SVector{4}(1,2,3,5), MVector{3,Bool}(0,0,1)),
 ]
-@test writeTableCF(qlist) == DataFrame(qind=[1,2],t1=[1,1],t2=[2,2],t3=[3,3],
+@test tablequartetCF(qlist) == DataFrame(qind=[1,2],t1=[1,1],t2=[2,2],t3=[3,3],
     t4=[4,5],CF12_34=[false,false],CF13_24=[true,false],CF14_23=[false,true])
 # with taxon names
-@test writeTableCF(qlist, ["a","b","c","d","e"]) == DataFrame(
+@test tablequartetCF(qlist, ["a","b","c","d","e"]) == DataFrame(
   qind=[1,2],t1=["a","a"],t2=["b","b"],t3=["c","c"],t4=["d","e"],
   CF12_34=[false,false],CF13_24=[true,false],CF14_23=[false,true])
 # 3x2 data, Int8-valued
 qlist = [PN.QuartetT(1, SVector{4}(1,2,3,4), MMatrix{3,2,Int8}(1:6))]
-@test writeTableCF(qlist) == DataFrame(qind=1,t1=1,t2=2,t3=3,t4=4,
+@test tablequartetCF(qlist) == DataFrame(qind=1,t1=1,t2=2,t3=3,t4=4,
     CF12_34=Int8[1], CF13_24=Int8[2], CF14_23=Int8[3],
     V2_12_34=Int8[4],V2_13_24=Int8[5],V2_14_23=Int8[6])
 # custom column names
-@test_logs (:error, r"^'colnames'") writeTableCF(qlist, colnames=["v1","v2"])
-@test writeTableCF(qlist, colnames=["v1","v2","v3","w1","w2","w3"]) ==
+@test_logs (:error, r"^'colnames'") tablequartetCF(qlist, colnames=["v1","v2"])
+@test tablequartetCF(qlist, colnames=["v1","v2","v3","w1","w2","w3"]) ==
   DataFrame(qind=1,t1=1,t2=2,t3=3,t4=4, v1=Int8[1],v2=Int8[2],v3=Int8[3],
     w1=Int8[4],w2=Int8[5],w3=Int8[6])
 end
@@ -40,9 +40,9 @@ dir = "/Users/ane/Documents/private/concordance/quartetNetwork/multiind/data"
 treefile = joinpath(dir, "raxml_1387_sample_5species4alleles.tre")
 tree = readmultinewick(treefile); # 1387 trees
 # extrema([t.numtaxa for t in tree]) # 4-16 taxa in each
-@time df1 = writeTableCF(countquartetsintrees(tree)...)
+@time df1 = tablequartetCF(countquartetsintrees(tree)...)
 # 0.139761 seconds (900.12 k allocations: 52.000 MiB, 11.52% gc time). 3876×8 DataFrames.DataFrame
-@time df2 = writeTableCF(readTrees2CF(tree, writeTab=false, writeSummary=false))
+@time df2 = tablequartetCF(readTrees2CF(tree, writeTab=false, writeSummary=false))
 # 13.154085 seconds (84.86 M allocations: 10.010 GiB, 7.21% gc time).  3876×8 DataFrames.DataFrame
 df12 = innerjoin(df1, df2, on=[:t1,:t2,:t3,:t4], makeunique=true)
 @test all([df12[:,4+i] == df12[:,8+i] for i in 1:4])
@@ -78,18 +78,18 @@ mappingfile = joinpath(dir, "strain2bin_map.csv")
 
 taxonmap = DataFrame(CSV.File(mappingfile); copycols=false) # 110×3 DataFrames.DataFrame
 taxonmap = Dict(taxonmap[i,:allele] => taxonmap[i,:species] for i in 1:110)
-@time df1 = writeTableCF(countquartetsintrees(tree, taxonmap; weight_byallele=true)...)
+@time df1 = tablequartetCF(countquartetsintrees(tree, taxonmap; weight_byallele=true)...)
 # 0.119289 seconds (698.57 k allocations: 43.305 MiB, 17.40% gc time). 5×8 DataFrames.DataFrame
 ## larger examples: 98 to 110 taxa, 1387 trees
 tree = readmultinewick(joinpath(dir, "raxml_1387.tre")) # 1387 trees, 98-110 taxa in each
-@time df1 = writeTableCF(countquartetsintrees(tree)...)
+@time df1 = tablequartetCF(countquartetsintrees(tree)...)
 # 1219.94 seconds = 20.3 min (298.45 M allocations: 8.509 GiB, 0.79% gc time). 5773185×8 DataFrames.DataFrame
 ## mid-size example: to be able to run the slower algorithm and compare times
 tree = readmultinewick(joinpath(dir, "raxml_1387_sample_13species4alleles.tre")); # 1387 trees, 19-40 taxa in each
-@time df1 = writeTableCF(countquartetsintrees(tree)...)
+@time df1 = tablequartetCF(countquartetsintrees(tree)...)
 # 5.639443 seconds (16.84 M allocations: 568.496 MiB, 7.50% gc time). 292825×8 DataFrame
 # ~ 600 times faster
-@time df2 = writeTableCF(readTrees2CF(tree, writeTab=false, writeSummary=false))
+@time df2 = tablequartetCF(readTrees2CF(tree, writeTab=false, writeSummary=false))
 # 3365.783672 seconds = 50.1 min (13.43 G allocations: 2.665 TiB, 21.33% gc time). 292825×8 DataFrame
 df12 = innerjoin(df1, df2, on=[:t1,:t2,:t3,:t4], makeunique=true)
 @test df12[!,8] ≈ df12[!,12] # number of genes

--- a/test/test_quartet.jl
+++ b/test/test_quartet.jl
@@ -1,0 +1,99 @@
+PN = PhyloNetworks
+
+@testset "QuartetT basic tests" begin
+# basic tests for QuartetT type
+nCk = PN.nchoose1234(5)
+oneQ = PN.QuartetT(1,3,4,6, [.92,.04,.04, 100], nCk)
+@test string(oneQ) == "4-taxon set number 8; taxon numbers: 1,3,4,6\ndata: [0.92, 0.04, 0.04, 100.0]"
+
+end
+
+@testset "convert QuartetT vector to dataframe" begin
+SVector = PN.StaticArrays.SVector
+MVector = PN.StaticArrays.MVector
+MMatrix = PN.StaticArrays.MMatrix
+# without taxon names, length-3 vector of boolean data
+qlist = [
+  PN.QuartetT(1, SVector{4}(1,2,3,4), MVector{3,Bool}(0,1,0)),
+  PN.QuartetT(2, SVector{4}(1,2,3,5), MVector{3,Bool}(0,0,1)),
+]
+@test writeTableCF(qlist) == DataFrame(qind=[1,2],t1=[1,1],t2=[2,2],t3=[3,3],
+    t4=[4,5],CF12_34=[false,false],CF13_24=[true,false],CF14_23=[false,true])
+# with taxon names
+@test writeTableCF(qlist, ["a","b","c","d","e"]) == DataFrame(
+  qind=[1,2],t1=["a","a"],t2=["b","b"],t3=["c","c"],t4=["d","e"],
+  CF12_34=[false,false],CF13_24=[true,false],CF14_23=[false,true])
+# 3x2 data, Int8-valued
+qlist = [PN.QuartetT(1, SVector{4}(1,2,3,4), MMatrix{3,2,Int8}(1:6))]
+@test writeTableCF(qlist) == DataFrame(qind=1,t1=1,t2=2,t3=3,t4=4,
+    CF12_34=Int8[1], CF13_24=Int8[2], CF14_23=Int8[3],
+    V2_12_34=Int8[4],V2_13_24=Int8[5],V2_14_23=Int8[6])
+# custom column names
+@test_logs (:error, r"^'colnames'") writeTableCF(qlist, colnames=["v1","v2"])
+@test writeTableCF(qlist, colnames=["v1","v2","v3","w1","w2","w3"]) ==
+  DataFrame(qind=1,t1=1,t2=2,t3=3,t4=4, v1=Int8[1],v2=Int8[2],v3=Int8[3],
+    w1=Int8[4],w2=Int8[5],w3=Int8[6])
+end
+
+if false # was used to time `countquartetsintrees` vs `readTrees2CF`
+dir = "/Users/ane/Documents/private/concordance/quartetNetwork/multiind/data"
+treefile = joinpath(dir, "raxml_1387_sample_5species4alleles.tre")
+tree = readmultinewick(treefile); # 1387 trees
+# extrema([t.numtaxa for t in tree]) # 4-16 taxa in each
+@time df1 = writeTableCF(countquartetsintrees(tree)...)
+# 0.139761 seconds (900.12 k allocations: 52.000 MiB, 11.52% gc time). 3876×8 DataFrames.DataFrame
+@time df2 = writeTableCF(readTrees2CF(tree, writeTab=false, writeSummary=false))
+# 13.154085 seconds (84.86 M allocations: 10.010 GiB, 7.21% gc time).  3876×8 DataFrames.DataFrame
+df12 = innerjoin(df1, df2, on=[:t1,:t2,:t3,:t4], makeunique=true)
+@test all([df12[:,4+i] == df12[:,8+i] for i in 1:4])
+# using BenchmarkTools
+# @benchmark countquartetsintrees(tree)
+#=
+memory estimate:  49.08 MiB
+allocs estimate:  788504
+--------------
+minimum time:     110.907 ms (10.89% GC)
+median time:      121.782 ms (11.20% GC)
+mean time:        125.725 ms (14.00% GC)
+maximum time:     227.248 ms (54.16% GC)
+--------------
+samples:          40
+evals/sample:     1
+=#
+# @benchmark readTrees2CF(tree, writeTab=false, writeSummary=false)
+#=
+BenchmarkTools.Trial:
+  memory estimate:  10.01 GiB
+  allocs estimate:  84744840
+  --------------
+  minimum time:     13.547 s (8.63% GC)
+  median time:      13.547 s (8.63% GC)
+  mean time:        13.547 s (8.63% GC)
+  maximum time:     13.547 s (8.63% GC)
+  --------------
+  samples:          1
+  evals/sample:     1
+=#
+mappingfile = joinpath(dir, "strain2bin_map.csv")
+
+taxonmap = DataFrame(CSV.File(mappingfile); copycols=false) # 110×3 DataFrames.DataFrame
+taxonmap = Dict(taxonmap[i,:allele] => taxonmap[i,:species] for i in 1:110)
+@time df1 = writeTableCF(countquartetsintrees(tree, taxonmap; weight_byallele=true)...)
+# 0.119289 seconds (698.57 k allocations: 43.305 MiB, 17.40% gc time). 5×8 DataFrames.DataFrame
+## larger examples: 98 to 110 taxa, 1387 trees
+tree = readmultinewick(joinpath(dir, "raxml_1387.tre")) # 1387 trees, 98-110 taxa in each
+@time df1 = writeTableCF(countquartetsintrees(tree)...)
+# 1219.94 seconds = 20.3 min (298.45 M allocations: 8.509 GiB, 0.79% gc time). 5773185×8 DataFrames.DataFrame
+## mid-size example: to be able to run the slower algorithm and compare times
+tree = readmultinewick(joinpath(dir, "raxml_1387_sample_13species4alleles.tre")); # 1387 trees, 19-40 taxa in each
+@time df1 = writeTableCF(countquartetsintrees(tree)...)
+# 5.639443 seconds (16.84 M allocations: 568.496 MiB, 7.50% gc time). 292825×8 DataFrame
+# ~ 600 times faster
+@time df2 = writeTableCF(readTrees2CF(tree, writeTab=false, writeSummary=false))
+# 3365.783672 seconds = 50.1 min (13.43 G allocations: 2.665 TiB, 21.33% gc time). 292825×8 DataFrame
+df12 = innerjoin(df1, df2, on=[:t1,:t2,:t3,:t4], makeunique=true)
+@test df12[!,8] ≈ df12[!,12] # number of genes
+hasdata = map(iszero, df12[!,8]) # sum: 34 four-taxon sets have data for 0 genes
+df12[hasdata,5:12] # countquartetsintrees gives 0s, readTrees2CF gives NaN
+@test all([df12[.!hasdata,4+i] ≈ df12[.!hasdata,8+i] for i in 1:3]) # true. yeah!
+end

--- a/test/test_quartet.jl
+++ b/test/test_quartet.jl
@@ -17,25 +17,35 @@ qlist = [
   PN.QuartetT(1, SVector{4}(1,2,3,4), MVector{3,Bool}(0,1,0)),
   PN.QuartetT(2, SVector{4}(1,2,3,5), MVector{3,Bool}(0,0,1)),
 ]
-@test tablequartetCF(qlist) == DataFrame(qind=[1,2],t1=[1,1],t2=[2,2],t3=[3,3],
+@test tablequartetCF(qlist) == (qind=[1,2],t1=[1,1],t2=[2,2],t3=[3,3],
     t4=[4,5],CF12_34=[false,false],CF13_24=[true,false],CF14_23=[false,true])
 # with taxon names
-@test tablequartetCF(qlist, ["a","b","c","d","e"]) == DataFrame(
+@test tablequartetCF(qlist, ["a","b","c","d","e"]) == (
   qind=[1,2],t1=["a","a"],t2=["b","b"],t3=["c","c"],t4=["d","e"],
   CF12_34=[false,false],CF13_24=[true,false],CF14_23=[false,true])
 # 3x2 data, Int8-valued
 qlist = [PN.QuartetT(1, SVector{4}(1,2,3,4), MMatrix{3,2,Int8}(1:6))]
-@test tablequartetCF(qlist) == DataFrame(qind=1,t1=1,t2=2,t3=3,t4=4,
+@test tablequartetCF(qlist) == (qind=[1],t1=[1],t2=[2],t3=[3],t4=[4],
     CF12_34=Int8[1], CF13_24=Int8[2], CF14_23=Int8[3],
     V2_12_34=Int8[4],V2_13_24=Int8[5],V2_14_23=Int8[6])
 # custom column names
 @test_logs (:error, r"^'colnames'") tablequartetCF(qlist, colnames=["v1","v2"])
 @test tablequartetCF(qlist, colnames=["v1","v2","v3","w1","w2","w3"]) ==
-  DataFrame(qind=1,t1=1,t2=2,t3=3,t4=4, v1=Int8[1],v2=Int8[2],v3=Int8[3],
+  (qind=[1],t1=[1],t2=[2],t3=[3],t4=[4], v1=Int8[1],v2=Int8[2],v3=Int8[3],
     w1=Int8[4],w2=Int8[5],w3=Int8[6])
+# quartet data: length-4 vectors, second 4-taxon set with 0 genes
+qlist = [
+  PN.QuartetT(1, SVector{4}(1,2,3,4), MVector{4,Int8}(0,1,0,10)),
+  PN.QuartetT(2, SVector{4}(1,2,3,5), MVector{4,Int8}(0,0,1, 0)),
+  PN.QuartetT(3, SVector{4}(1,2,4,5), MVector{4,Int8}(1,0,0, 5)),
+]
+@test tablequartetCF(qlist) == (qind=[1,3],t1=[1,1],t2=[2,2],t3=[3,4], t4=[4,5],
+  CF12_34=[0,1],CF13_24=[1,0],CF14_23=[0,0], ngenes=[10,5])
 end
 
-if false # was used to time `countquartetsintrees` vs `readTrees2CF`
+if false # was used to time countquartetsintrees vs readTrees2CF under PN ≤ v0.16
+# under PN v1: countquartetsintrees returns a NamedTuple, not a DataFrame,
+#              and readTrees2CF was moved to SNaQ.
 dir = "/Users/ane/Documents/private/concordance/quartetNetwork/multiind/data"
 treefile = joinpath(dir, "raxml_1387_sample_5species4alleles.tre")
 tree = readmultinewick(treefile); # 1387 trees

--- a/test/test_recursion_matrices.jl
+++ b/test/test_recursion_matrices.jl
@@ -32,11 +32,11 @@ for i in 1:9
 end
 
 nodesV2 = [-2, 1, -3, -4, -5, 2, 3, 4, 5] # root was number 6 before: with readTopologyLevel1 + rootatnode
-ind = indexin(V1.nodeNumbersTopOrder, nodesV2)
+ind = indexin(V1.nodenumbers_toporder, nodesV2)
 V2 = V2[ind, ind]
 @test_logs show(devnull, V2)
 
-@test V1[:All] ≈ V2
+@test V1[:all] ≈ V2
 
 ########################
 ## vcv function
@@ -44,7 +44,7 @@ V2 = V2[ind, ind]
 
 ## Simple test
 C = Matrix(vcv(net))
-@test C ≈ V1[:Tips]
+@test C ≈ V1[:tips]
 vv = diag(C)
 for i in 1:4
     for j in 1:4
@@ -81,7 +81,7 @@ T2 =  [1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
        1.0  1.0  0.0  0.0  1.0  0.0  0.0  1.0  0.0
        1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0]
 
-@test T[:All] ≈ T2
+@test T[:all] ≈ T2
 
 ##################
 ## New formula
@@ -122,12 +122,12 @@ V_t_2 = sharedpathmatrix(net)
 
 ## Descendant indicatrice matrix
 des = PhyloNetworks.descendants(par_edge_1, true) # true to get internal nodes also
-mask = indexin(des, V_t_1.nodeNumbersTopOrder)
+mask = indexin(des, V_t_1.nodenumbers_toporder)
 D = zeros(net.numnodes, net.numnodes)
 D[mask, mask] .= 1.0
 
 ## Formula
-V2 = gam*V_t_1[:All] + (1-gam)*V_t_2[:All] - gam*(1-gam) * (V_t_1.V[p, p] - V_t_1.V[a, b] + V_t_2.V[p, p] - V_t_2.V[a, b]) .* D
+V2 = gam*V_t_1[:all] + (1-gam)*V_t_2[:all] - gam*(1-gam) * (V_t_1.V[p, p] - V_t_1.V[a, b] + V_t_2.V[p, p] - V_t_2.V[a, b]) .* D
 
-@test V1[:All] ≈ V2
+@test V1[:all] ≈ V2
 end


### PR DESCRIPTION
new feature: `tablequartetCF` (was `writeTableCF` in v0.16 but now returns NamedTuple, and has option to skip 4-taxon sets with no informative genes)

breaking changes: renaming with small case