### PR TITLE
expected f-statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Utilities in this core package include:
 To get help, check
 
 - the [latest documentation](https://juliaphylo.github.io/PhyloNetworks.jl/dev)
-- the [wiki](https://github.com/juliaphylo/PhyloNetworks.jl/wiki) for a
-  step-by-step tutorial with background on networks (last revised 2022)
+- PhyloUtilities: [website](https://juliaphylo.github.io/PhyloUtilities/) for a
+  step-by-step tutorial with background on networks, and associated
+  [scripts](https://github.com/JuliaPhylo/PhyloUtilities/tree/main/scripts)
 - [tutorial](https://cecileane.github.io/networkPCM-workshop/) for
   comparative methods, including network calibration (2023 workshop)
 - the [google group](https://groups.google.com/forum/#!forum/juliaphylo-users)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,7 +13,7 @@ links = InterLinks(
     "PhyloPlots" => "https://juliaphylo.github.io/PhyloPlots.jl/stable/objects.inv",
     "SNaQ" => "https://juliaphylo.github.io/SNaQ.jl/stable/objects.inv",
     "QGoF" => "https://juliaphylo.github.io/QuartetNetworkGoodnessFit.jl/stable/objects.inv",
-    # "PhyloTraits"=> "https://juliaphylo.github.io/PhyloTraits.jl/stable/objects.inv",
+    "PhyloTraits"=> "https://juliaphylo.github.io/PhyloTraits.jl/stable/objects.inv",
 )
 # default loading of interlinked packages in all docstring examples
 DocMeta.setdocmeta!(PhyloNetworks, :DocTestSetup,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,7 @@
 using Documenter
 
+ENV["COLUMNS"] = 90 # see ? displaysize: defaults to 80 columns
+
 # this installs the dev version of PhyloPlots for compatibility.
 using Pkg
 Pkg.add(PackageSpec(name="PhyloPlots", rev="master"))
@@ -11,8 +13,8 @@ using PhyloNetworks
 using DocumenterInterLinks
 links = InterLinks(
     "PhyloPlots" => "https://juliaphylo.github.io/PhyloPlots.jl/stable/objects.inv",
-    "SNaQ" => "https://juliaphylo.github.io/SNaQ.jl/stable/objects.inv",
-    "QGoF" => "https://juliaphylo.github.io/QuartetNetworkGoodnessFit.jl/stable/objects.inv",
+    #"SNaQ" => "https://juliaphylo.github.io/SNaQ.jl/stable/objects.inv",
+    "QuartetNetworkGoodnessFit" => "https://juliaphylo.github.io/QuartetNetworkGoodnessFit.jl/stable/objects.inv",
     "PhyloTraits"=> "https://juliaphylo.github.io/PhyloTraits.jl/stable/objects.inv",
 )
 # default loading of interlinked packages in all docstring examples

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,8 @@ using PhyloNetworks
 using DocumenterInterLinks
 links = InterLinks(
     "PhyloPlots" => "https://juliaphylo.github.io/PhyloPlots.jl/stable/objects.inv",
-    # "SNaQ"       => "https://juliaphylo.github.io/SNaQ.jl/stable/objects.inv",
+    "SNaQ" => "https://juliaphylo.github.io/SNaQ.jl/stable/objects.inv",
+    "QGoF" => "https://juliaphylo.github.io/QuartetNetworkGoodnessFit.jl/stable/objects.inv",
     # "PhyloTraits"=> "https://juliaphylo.github.io/PhyloTraits.jl/stable/objects.inv",
 )
 # default loading of interlinked packages in all docstring examples

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,6 +47,7 @@ makedocs(
             "Network support" => "man/network_support.md",
             "Parsimony on networks" => "man/parsimony.md",
             "Neighbour Joining" => "man/nj.md",
+            "Pairwise and quartet data" => "man,expecteddata.md",
         ],
         "Library" => [
             "Public" => "lib/public.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,7 +47,7 @@ makedocs(
             "Network support" => "man/network_support.md",
             "Parsimony on networks" => "man/parsimony.md",
             "Neighbour Joining" => "man/nj.md",
-            "Pairwise and quartet data" => "man,expecteddata.md",
+            "Pairwise and quartet data" => "man/expecteddata.md",
         ],
         "Library" => [
             "Public" => "lib/public.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,9 +32,10 @@ It is used by other packages for more specialized tasks, such as
 
 **How to get help**
 
-- the package [wiki](https://github.com/juliaphylo/PhyloNetworks.jl/wiki) has a
-  step-by-step tutorial, done for the MBL workshop (last revised 2022),
-  with background on networks and explanations.
+- PhyloUtilities: [website](https://juliaphylo.github.io/PhyloUtilities/) for a
+  step-by-step tutorial with background on networks
+  (done for the MBL workshop, last revised 2022) and associated
+  [scripts](https://github.com/JuliaPhylo/PhyloUtilities/tree/main/scripts)
 - [tutorial](https://cecileane.github.io/networkPCM-workshop/) for
   comparative methods, including network calibration (2023 workshop)
 - the [google group](https://groups.google.com/forum/#!forum/juliaphylo-users)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -65,7 +65,8 @@ Pages = [
     "man/dist_reroot.md",
     "man/network_support.md",
     "man/parsimony.md",
-    "man/nj.md"
+    "man/nj.md",
+    "man/expecteddata.md",
 ]
 Depth = 3
 ```

--- a/docs/src/man/expecteddata.md
+++ b/docs/src/man/expecteddata.md
@@ -35,7 +35,7 @@ plot(net2, showgamma=true, useedgelength=true, style=:majortree, arrowlen=0.1, t
 R"mtext"("net2, showing γ's", line=-1);
 R"dev.off"();
 ```
-![net0 and net2](../assets/figures/expectedata_fig_net02.svg)
+![net02-distquartet](../assets/figures/expectedata_fig_net02.svg)
 
 ## average pairwise distances
 
@@ -162,27 +162,31 @@ for q in f4
 end
 ```
 
-For each set of 4 taxa, the 3 f4s sum up to 0: as it should be.
+For each set of 4 taxa, the three f4s sum up to 0: as it should be.
 On a tree with a split `t1,t2|t4,t5`, the corresponding f4 value should
-be 0, and the other 2 should give ± the length of the branch separating
+be 0, and the other 2 should give ± the length of the internal path separating
 the 2 groups of 2 taxa.
 (Again, the branch lengths unit depends on the data being considered.)
 
 Here for example, the first 4-taxon set is `A,B,C,D`. In our tree,
 `BC` is a clade, separated from `AD` by a branch of length 2.
-Accordingly, the third f4 value, corresponding to `AD|CB`, is 0.
-The other two f4s are 2 or -2.
+Accordingly, the third f4 value, corresponding to `AD|BC`, is 0;
+and the other two f4s are 2 or -2.
+
+![net02-distquartet-again](../assets/figures/expectedata_fig_net02.svg)
 
 We can see how adding reticulations to our tree affects expected f4s.
+Note the colums names below: they correspond to the order of taxa
+for each f4.
 
 ```@repl edata
 f4,t = expectedf4table(net2, showprogressbar=false); # same t: alphabetically
-nt = tablequartetdata(f4, t; prefix="f4_"); # convert to table
-df = DataFrame(nt) # then to data frame
+nt = tablequartetdata(f4, t; colnames="f4_" .* ["12_34", "13_42", "14_23"]);
+df = DataFrame(nt) # convert table to data frame
 ```
 
-We still have f4=0 on the 3rd column for taxon set `A,B,C,D`, because `BC` are
-still sister in the network.
+We still have f4=0 on the 3rd column for first taxon set `A,B,C,D`,
+because `BC` are still sister in the network.
 But the last taxon set for example, `C,D,E,O`, has no 0 values of f4
 due to the reticulation between ancestors of `D` and `E`:
 in the subnetwork for `C,D,E,O`, there is a cycle of 4 edges.

--- a/docs/src/man/expecteddata.md
+++ b/docs/src/man/expecteddata.md
@@ -1,0 +1,63 @@
+```@setup edata
+using PhyloNetworks
+using DataFrames, CSV
+using RCall, PhyloPlots
+figname(x) = joinpath("..", "assets", "figures", x)
+```
+
+# Pairwise and quartet data
+
+We show here some functionalities to calculate data expected
+from a given network, or observed in data.
+To calculate expectations under a given network, this network
+needs to have branch lengths and γ inheritances at hybrids.
+
+We use 2 example networks in this section:
+`net0` without reticulations (a tree) and
+`net2` with 2 reticulations.
+`net0` is in fact `net2`'s major tree: obtained by
+deleting every minor hybrid edge.
+
+```@example edata
+net0 = readnewick("(O:5.5,((E:4.0,(D:3.0,(C:1.0,B:1.0):2.0):1.0):1.0,A:5.0):0.5);");
+net2 = readnewick("(O:5.5,(((E:1.5)#H1:2.5::0.7,((#H1:0,D:1.5):1.5,((C:1,B:1):1)#H2:1::0.6):1.0):1.0,(#H2:0,A:2):3):0.5);")
+```
+
+```@eval edata
+using RCall, PhyloPlots
+R"svg"(figname("expectedata_fig_net02.svg"), width=7, height=3);
+R"layout"([1 2]);
+R"par"(mar=[0,0,0.5,0]);
+plot(net0, useedgelength=true, showedgelength=true, tipoffset=0.1);
+R"mtext"("net0, showing edge lengths", line=-1);
+plot(net2, showgamma=true, useedgelength=true, style=:majortree, arrowlen=0.1, tipoffset=0.1);
+R"mtext"("net2, showing γ's", line=-1);
+R"dev.off"();
+```
+![net0 and net2](../assets/figures/expectedata_fig_net02.svg)
+
+## average pairwise distances
+
+coming next: example to use
+[`pairwisetaxondistancematrix`](@ref)
+
+perhaps: extract from [`startingBL!`](@ref) the code to calculate
+pairwise distances from data, either Hamming or JC-corrected,
+and show how to use it here.
+
+## expected f2-statistics
+
+coming next: example to use
+[`expectedf2matrix`](@ref)
+
+## expected f4-statistics
+
+coming next: example to use
+- a new function to calculate f3, and
+- a new function to calculate f4 expected from a network
+
+## quartet concordance factors
+
+coming next: example to use
+[`countquartetsintrees`](@ref) and [`tablequartetCF`](@ref)
+Refer to QGoF for expected qCFs.

--- a/docs/src/man/expecteddata.md
+++ b/docs/src/man/expecteddata.md
@@ -153,11 +153,9 @@ first(f4,2) # first 2 4-taxon sets, each with 3 quartet f4s
 The taxon numbers above are indices in the taxon list `t`.
 Here is a way to print all f4 statistics expected from our tree `net0`:
 ```@example edata
-print(join(
-    [join(t[q.taxonnumber],",") * ": " * string(round.(q.data, sigdigits=2))
-     for q in f4],
-    "\n")
-)
+for q in f4
+    println(join(t[q.taxonnumber],",") * ": " * string(round.(q.data, sigdigits=2)))
+end
 ```
 
 For each set of 4 taxa, the 3 f4s sum up to 0: as it should be.

--- a/docs/src/man/expecteddata.md
+++ b/docs/src/man/expecteddata.md
@@ -144,9 +144,35 @@ DataFrame(f2D_net2, taxonlist2)
 
 ## expected f4-statistics
 
+```@example edata
+f4,t = PN.expectedf4table(net0);
+t # taxa, but ordered alphabetically: not as in tiplabels(net0)
+first(f4,2) # first 2 4-taxon sets, each with 3 quartet f4s
+```
+
+The taxon numbers above are indices in the taxon list `t`.
+Here is a way to print all f4 statistics expected from our tree `net0`:
+```@example edata
+print(join(
+    [join(t[q.taxonnumber],",") * ": " * string(round.(q.data, sigdigits=2))
+     for q in f4],
+    "\n")
+)
+```
+
+For each set of 4 taxa, the 3 f4s sum up to 0: as it should be.
+On a tree with a split `t1,t2|t4,t5`, the corresponding f4 value should
+be 0, and the other 2 should give ± the length of the branch separating
+the 2 groups of 2 taxa.
+Here for example, the first 4-taxon set is `A,B,C,D`. In our tree,
+`BC` is a clade, separated from `AD` by a branch of length 2.
+Accordingly, the third f4 value, corresponding to `AD|CB`, is 0.
+The other two f4s are 2 or -2.
+
 coming next: example to use
-- a new function to calculate f3, and
-- a new function to calculate f4 expected from a network
+- `expectedf4table` on `net2`, and convert the result to a data frame
+- a new function to calculate f3.
+
 
 ## quartet concordance factors
 

--- a/docs/src/man/expecteddata.md
+++ b/docs/src/man/expecteddata.md
@@ -2,6 +2,7 @@
 using PhyloNetworks
 using DataFrames, CSV
 using RCall, PhyloPlots
+mkpath("../assets/figures")
 figname(x) = joinpath("..", "assets", "figures", x)
 ```
 
@@ -21,9 +22,10 @@ deleting every minor hybrid edge.
 ```@example edata
 net0 = readnewick("(O:5.5,((E:4.0,(D:3.0,(C:1.0,B:1.0):2.0):1.0):1.0,A:5.0):0.5);");
 net2 = readnewick("(O:5.5,(((E:1.5)#H1:2.5::0.7,((#H1:0,D:1.5):1.5,((C:1,B:1):1)#H2:1::0.6):1.0):1.0,(#H2:0,A:2):3):0.5);")
+nothing # hide
 ```
 
-```@eval edata
+```@setup edata
 using RCall, PhyloPlots
 R"svg"(figname("expectedata_fig_net02.svg"), width=7, height=3);
 R"layout"([1 2]);
@@ -38,17 +40,58 @@ R"dev.off"();
 
 ## average pairwise distances
 
-coming next: example to use
-[`pairwisetaxondistancematrix`](@ref)
+One distance between pairs of taxa, say between t1 and t2, is the
+average length of all "up-down" paths in the network to go from t1 to t2,
+see [Xu & Ané 2023](https://doi.org/10.1007/s00285-022-01847-8) for example.
+In a tree, there is a single such path: going up from t1 to their
+most recent common ancestor, then down to t2.
+In a general network, there can be multiple paths.
+Each path has an inheritance weight: the product of the inheritance γ's of
+all edges in the path.
+Under a simple model, this is the proportion of genetic material that took
+this path.
+The average distance betwen t1 and t2 is the weighted average of these
+paths' lengths, weighted by the paths' inheritance.
 
-perhaps: extract from [`startingBL!`](@ref) the code to calculate
-pairwise distances from data, either Hamming or JC-corrected,
+It can be calculated with [`pairwisetaxondistancematrix`](@ref).
+On our tree `net0`, we get this:
+
+```@repl edata
+aveD_net0 = pairwisetaxondistancematrix(net0)
+```
+The order of rows and columns in this matrix is the same as
+given by `tiplabels`. For example, we can convert the distance matrix
+`aveD_net0` to a data frame with a column named for each taxon like this.
+
+```@repl edata
+taxonlist0 = tiplabels(net0)
+using DataFrames
+DataFrame(aveD_net0, taxonlist0)
+```
+
+Using the network `net2`, we see that its reticulations bring
+E closer to D; and bring B & C closer to A (and away from D & E
+since A is distant from them):
+
+```@example edata
+aveD_net2 = pairwisetaxondistancematrix(net2);
+DataFrame(aveD_net2, tiplabels(net2))
+```
+
+todo perhaps: extract from [`PhyloNetworks.startingBL!`](@ref)
+the code to calculate pairwise distances from data,
+either Hamming or JC-corrected,
 and show how to use it here.
 
 ## expected f2-statistics
 
-coming next: example to use
-[`expectedf2matrix`](@ref)
+coming next: explain and expand example of using
+[`PhyloNetworks.expectedf2matrix`](@ref)
+
+```@example edata
+const PN = PhyloNetworks; # for lazy typing below!
+f2D_net0 = PN.expectedf2matrix(net0)
+```
 
 ## expected f4-statistics
 

--- a/docs/src/man/expecteddata.md
+++ b/docs/src/man/expecteddata.md
@@ -174,11 +174,36 @@ coming next: example to use
 
 ## quartet concordance factors
 
+The concordance factor of a quartet `ab|cd` is the proportion of the
+genome whose genealogy has this unrooted topology.
+
 Tools to calculate quartet concordance factors expected from
-a network are provided in package
+a network under the coalescent model are provided in package
 [QGoF](https://github.com/JuliaPhylo/QuartetNetworkGoodnessFit.jl):
 see its documentation about [expected concordance factors](@extref QGoF).
 
-coming next: example to use
-[`countquartetsintrees`](@ref) and [`tablequartetCF`](@ref)
-Refer to QGoF for expected qCFs.
+To calculate quartet concordance factors observed in data, one option is
+to count the number of gene trees that display each quartet, using
+[`countquartetsintrees`](@ref) and [`tablequartetCF`](@ref).
+
+In the example below, the 4th gene tree is missing taxon A, and
+the 6th gene tree has a polytomies (unresolved ABE clade), such as if
+a branch of low support was collapsed.
+The number of genes underlying each quartet is captured in the table below.
+
+```@example edata
+sixgenetrees_nwk = [
+  "(E,((A,B),(C,D)),O);","(((A,B),(C,D)),(E,O));","(A,B,((C,D),(E,O)));",
+  "(B,((C,D),(E,O)));","((C,D),(A,(B,E)),O);","((C,D),(A,B,E),O);"];
+genetrees = readnewick.(sixgenetrees_nwk);
+q,t = countquartetsintrees(genetrees, showprogressbar=false);
+df = tablequartetCF(q,t) |> DataFrame
+```
+
+If low-support branches are not collapsed, this counting method does not
+account for gene tree estimation error.
+(It biases concordance factors towards 1/3 for each resolution of a
+4-taxon tree: lack of knowledge is mistaken as lack of concordance).
+Estimation error can be accounted for in a Bayesian framework:
+see [PhyloUtilities](https://juliaphylo.github.io/PhyloUtilities/)
+for a pipeline.

--- a/docs/src/man/expecteddata.md
+++ b/docs/src/man/expecteddata.md
@@ -75,7 +75,8 @@ since A is distant from them):
 
 ```@example edata
 aveD_net2 = pairwisetaxondistancematrix(net2);
-DataFrame(aveD_net2, tiplabels(net2))
+taxonlist2 = tiplabels(net2)
+DataFrame(aveD_net2, taxonlist2)
 ```
 
 todo perhaps: extract from [`PhyloNetworks.startingBL!`](@ref)
@@ -85,12 +86,34 @@ and show how to use it here.
 
 ## expected f2-statistics
 
-coming next: explain and expand example of using
-[`PhyloNetworks.expectedf2matrix`](@ref)
+The f2-statistic gives another measure of dissimilarity between pairs of taxa
+(see [Lipson 2020](https://doi.org/10.1111/1755-0998.13230) for example).
+The expected value of f2 between taxa t₁ and t₂ is
+```math
+f_2(t_1, t_2) = E(X(t_1) - X(t_2))^2
+```
+under a Brownian motion model for trait X evolving along the network,
+where X(t₁) and X(t₂) are the values of X for taxa t₁ and t₂.
+
+If the network is a tree, then this is exactly the average distance
+(or simply, the length of the unique path) between t₁ and t₂.
+
+It can be calculated with [`PhyloNetworks.expectedf2matrix`](@ref).
+On our tree `net0`, we an f2 matrix equal to the average distance matrix:
 
 ```@example edata
 const PN = PhyloNetworks; # for lazy typing below!
 f2D_net0 = PN.expectedf2matrix(net0)
+f2D_net0 == aveD_net0
+```
+
+Again, taxa are listed along rows and along columns in the same
+order as listed by `tiplabels()`.  
+On our network `net2`, the f2 and average distances differ:
+
+```@example edata
+f2D_net2 = PN.expectedf2matrix(net2)
+DataFrame(f2D_net2, taxonlist2)
 ```
 
 ## expected f4-statistics
@@ -100,6 +123,11 @@ coming next: example to use
 - a new function to calculate f4 expected from a network
 
 ## quartet concordance factors
+
+Tools to calculate quartet concordance factors expected from
+a network are provided in package
+[QGoF](https://github.com/JuliaPhylo/QuartetNetworkGoodnessFit.jl):
+see its documentation about [expected concordance factors](@extref QGoF).
 
 coming next: example to use
 [`countquartetsintrees`](@ref) and [`tablequartetCF`](@ref)

--- a/docs/src/man/expecteddata.md
+++ b/docs/src/man/expecteddata.md
@@ -79,10 +79,36 @@ taxonlist2 = tiplabels(net2)
 DataFrame(aveD_net2, taxonlist2)
 ```
 
-todo perhaps: extract from [`PhyloNetworks.startingBL!`](@ref)
-the code to calculate pairwise distances from data,
-either Hamming or JC-corrected,
-and show how to use it here.
+To calculate pairwise distances observed in data, such as
+along a DNA alignment across multiple sites, we can use
+[`PhyloNetworks.hammingdistancematrix`](@ref).
+
+```@repl edata
+dna_data = [
+    ['T','G','T','A','G'], # taxon 1
+    ['T','G','A','A','G'],
+    ['T','G','A','A','C'],
+    ['T','G','A',missing,missing],
+    ['T','G','A','T','C'], # taxon 5
+];
+d = PhyloNetworks.hammingdistancematrix(dna_data)
+```
+
+Perhaps we want to give weights to each trait, such as if an alignment is
+summarized by keeping each site pattern once, weighted by the number of sites
+having this pattern:
+
+```@repl edata
+site_count = [3,2,1,1,1]; # invariable site patterns have higher counts
+d = PhyloNetworks.hammingdistancematrix(dna_data, site_count)
+```
+
+A Jukes-Cantor correction can be applied with
+[`PhyloNetworks.distancecorrection_JC!`](@ref):
+
+```@repl edata
+PhyloNetworks.distancecorrection_JC!(d, 4) # 4 states
+```
 
 ## expected f2-statistics
 

--- a/docs/src/man/expecteddata.md
+++ b/docs/src/man/expecteddata.md
@@ -19,7 +19,8 @@ deleting every minor hybrid edge.
 
 ```@example edata
 net0 = readnewick("(O:5.5,((E:4.0,(D:3.0,(C:1.0,B:1.0):2.0):1.0):1.0,A:5.0):0.5);");
-net2 = readnewick("(O:5.5,(((E:1.5)#H1:2.5::0.7,((#H1:0,D:1.5):1.5,((C:1,B:1):1)#H2:1::0.6):1.0):1.0,(#H2:0,A:2):3):0.5);")
+net2 = readnewick("(O:5.5,(((E:1.5)#H1:2.5::0.7,((#H1:0,D:1.5):1.5,
+    ((C:1,B:1):1)#H2:1::0.6):1.0):1.0,(#H2:0,A:2):3):0.5);")
 nothing # hide
 ```
 
@@ -39,8 +40,8 @@ R"dev.off"();
 ## average pairwise distances
 
 One distance between pairs of taxa, say between t1 and t2, is the
-average length of all "up-down" paths in the network to go from t1 to t2,
-see [Xu & Ané 2023](https://doi.org/10.1007/s00285-022-01847-8) for example.
+average length of all "up-down" paths in the network to go from t1 to t2
+(see [Xu & Ané 2023](https://doi.org/10.1007/s00285-022-01847-8) for example).
 In a tree, there is a single such path: going up from t1 to their
 most recent common ancestor, then down to t2.
 In a general network, there can be multiple paths.
@@ -71,9 +72,9 @@ Using the network `net2`, we see that its reticulations bring
 E closer to D; and bring B & C closer to A (and away from D & E
 since A is distant from them):
 
-```@example edata
+```@repl edata
 aveD_net2 = pairwisetaxondistancematrix(net2);
-taxonlist2 = tiplabels(net2)
+taxonlist2 = tiplabels(net2);
 DataFrame(aveD_net2, taxonlist2)
 ```
 
@@ -131,7 +132,7 @@ If the network is a tree, then this is exactly the average distance
 It can be calculated with [`expectedf2matrix`](@ref).
 On our tree `net0`, we get an f2 matrix equal to the average distance matrix:
 
-```@example edata
+```@repl edata
 f2D_net0 = expectedf2matrix(net0)
 f2D_net0 == aveD_net0
 ```
@@ -140,14 +141,14 @@ Again, taxa are listed along rows and along columns in the same
 order as listed by `tiplabels()`.  
 On our network `net2`, the f2 and average distances differ:
 
-```@example edata
-f2D_net2 = expectedf2matrix(net2)
+```@repl edata
+f2D_net2 = expectedf2matrix(net2);
 DataFrame(f2D_net2, taxonlist2)
 ```
 
 ## expected f4-statistics
 
-```@example edata
+```@repl edata
 f4,t = expectedf4table(net0);
 t # taxa, but ordered alphabetically: not as in tiplabels(net0)
 first(f4,2) # first 2 4-taxon sets, each with 3 quartet f4s
@@ -155,7 +156,7 @@ first(f4,2) # first 2 4-taxon sets, each with 3 quartet f4s
 
 The taxon numbers above are indices in the taxon list `t`.
 Here is a way to print all f4 statistics expected from our tree `net0`:
-```@example edata
+```@repl edata
 for q in f4
     println(join(t[q.taxonnumber],",") * ": " * string(round.(q.data, sigdigits=2)))
 end
@@ -174,21 +175,25 @@ The other two f4s are 2 or -2.
 
 We can see how adding reticulations to our tree affects expected f4s.
 
-```@example edata
+```@repl edata
 f4,t = expectedf4table(net2, showprogressbar=false); # same t: alphabetically
 nt = tablequartetdata(f4, t; prefix="f4_"); # convert to table
 df = DataFrame(nt) # then to data frame
 ```
 
-We still have f4=0 on the 3rd column for taxon set `A,B,C,D`, because BC are
+We still have f4=0 on the 3rd column for taxon set `A,B,C,D`, because `BC` are
 still sister in the network.
-But there are no 0 values of f4 for `C,D,E,O`, the last taxon set for example:
-due to the reticulation because ancestors of `D` and `E`, that results in
-a cycle of 4 edges in the subnetwork for `C,D,E,O`.
+But the last taxon set for example, `C,D,E,O`, has no 0 values of f4
+due to the reticulation between ancestors of `D` and `E`:
+in the subnetwork for `C,D,E,O`, there is a cycle of 4 edges.
 
-coming next: example to use
-- a new function to calculate f3.
+We may also calculate f3 statistics using [`PhyloNetworks.expectedf3matrix`](@ref).
+For this, we need a reference taxon. Here we use the outgroup O:
 
+```@repl edata
+f3_net2 = PhyloNetworks.expectedf3matrix(net2, "O");
+DataFrame(f3_net2, taxonlist2)
+```
 
 ## quartet concordance factors
 
@@ -198,7 +203,7 @@ genome whose genealogy has this unrooted topology.
 Tools to calculate quartet concordance factors expected from
 a network under the coalescent model are provided in package
 [QGoF](https://github.com/JuliaPhylo/QuartetNetworkGoodnessFit.jl):
-see its documentation about [expected concordance factors](@extref QGoF).
+see its documentation about [expected concordance factors](https://juliaphylo.github.io/QuartetNetworkGoodnessFit.jl/stable/man/expected_qCFs/#expected-concordance-factors).
 
 To calculate quartet concordance factors observed in data, one option is
 to count the number of gene trees that display each quartet, using
@@ -209,7 +214,7 @@ the 6th gene tree has a polytomies (unresolved ABE clade), such as if
 a branch of low support was collapsed.
 The number of genes underlying each quartet is captured in the table below.
 
-```@example edata
+```@repl edata
 sixgenetrees_nwk = [
   "(E,((A,B),(C,D)),O);","(((A,B),(C,D)),(E,O));","(A,B,((C,D),(E,O)));",
   "(B,((C,D),(E,O)));","((C,D),(A,(B,E)),O);","((C,D),(A,B,E),O);"];

--- a/docs/src/man/netmanipulation.md
+++ b/docs/src/man/netmanipulation.md
@@ -139,3 +139,12 @@ To calibrate a network (modify its edge lengths):
   guarantee that the 2 networks have the same topology in general.
   But it does if the networks are in some classes (e.g. trees, level-1,
   tree-child, and others).
+
+## Comparing taxa
+
+- average pairwise distances on a network: [`pairwisetaxondistancematrix`](@ref),  
+  and from data: [`PhyloNetworks.hammingdistancematrix](@ref), that can be
+  followed by [`PhyloNetworks.distancecorrection_JC!`](@ref)
+- f2-distances expected from a network: [`expectedf2matrix`](@ref)
+  which can be used to get expected f3 and expected f4 statistics:
+  [`PhyloNetworks.expectedf3matrix`](@ref) and [`expectedf4table`](@ref).

--- a/src/PhyloNetworks.jl
+++ b/src/PhyloNetworks.jl
@@ -148,6 +148,7 @@ module PhyloNetworks
     include("recursion_matrices.jl")
     include("parsimony.jl")
     include("pairwiseDistanceLS.jl")
+    include("expectedfstat.jl")
     include("interop.jl")
     include("graph_components.jl")
     include("deprecated.jl")

--- a/src/PhyloNetworks.jl
+++ b/src/PhyloNetworks.jl
@@ -109,10 +109,12 @@ module PhyloNetworks
         treeedges_support,
         hybridclades_support,
         readmultinewick_files,
-        ## Network Calibration
+        ## node & taxon distances
         getnodeages,
         pairwisetaxondistancematrix,
         calibratefrompairwisedistances!,
+        expectedf2matrix,
+        expectedf4table,
         # recursion
         sharedpathmatrix,
         descendencematrix,
@@ -125,6 +127,7 @@ module PhyloNetworks
         # neighbor joining
         nj,
         # quartets
+        tablequartetdata,
         tablequartetCF,
         countquartetsintrees
 

--- a/src/expectedfstat.jl
+++ b/src/expectedfstat.jl
@@ -95,15 +95,65 @@ Given a set of 4 taxa, there are 12 ways to order them, but there are only
 # example
 
 The first example is a tree: on which some f4 values are expected to be 0.
+```jldoctest
+julia> net0 = readTopology("((D:0.6,((a1:.1,a2:.1):0.1,B:0.2):0.3),C:0.4);");
 
-Next, we use a network with 2 reticulations, which contains a "32 cycle".
+julia> # using PhyloPlots; plot(net0, showedgelength=true);
+
+julia> f4,t = PhyloNetworks.expectedf4table(net0);
+Calculation of expected f4 for 5 4-taxon sets...
+0+-----+100%
+  *****
+
+julia> show(t)
+["B", "C", "D", "a1", "a2"]
+julia> show(f4[1].taxonnumber) # taxa numbered 1-4 are: B,C,D,a1
+[1, 2, 3, 4]
+julia> for q in f4
+         println(join(t[q.taxonnumber],",") * ": " * string(round.(q.data, digits=3)))
+       end
+B,C,D,a1: [-0.3, 0.3, 0.0]
+B,C,D,a2: [-0.3, 0.3, 0.0]
+B,C,a1,a2: [0.0, -0.1, 0.1]
+B,D,a1,a2: [0.0, -0.1, 0.1]
+C,D,a1,a2: [0.0, -0.4, 0.4]
+```
+The zeros correspond to splits in the tree:
+Ba1|CD, Ba2|CD, BC|a1a2, BD|a1a2, CD|a1a2.
+The other values correspond to the internal path length for each split.
+
+Next, we use a network with 2 reticulations, each time between sister species
+(resulting in 3-cycle blobs).
 
 ```jldoctest
 julia> net = readTopology("(D:1,((C:1,#H25:0):0.1,((((B1:10,B2:1):1.5,#H1:0):10.8,((A1:1,A2:1):0.001)#H1:0::0.5):0.5)#H25:0::0.501):1);");
 
-julia> # using PhyloPlots; plot(net, showedgelength=true);
+julia> # plot(net, showedgelength=true);
 
-julia> q,t = expectedf4table(net);
+julia> f4,t = PhyloNetworks.expectedf4table(net, showprogressbar=false);
+
+julia> using DataFrames
+
+julia> df = PhyloNetworks.tablequartetdata(f4, t; prefix="f4_") |> DataFrame
+15×8 DataFrame
+ Row │ qind   t1      t2      t3      t4      f4_12_34  f4_13_24  f4_14_23 
+     │ Int64  String  String  String  String  Float64   Float64   Float64  
+─────┼─────────────────────────────────────────────────────────────────────
+   1 │     1  A1      A2      B1      B2           0.0    -4.201     4.201
+   2 │     2  A1      A2      B1      C            0.0     2.699    -2.699
+   3 │     3  A1      A2      B2      C            0.0     2.699    -2.699
+   4 │     4  A1      B1      B2      C           -6.9     6.9       0.0
+   5 │     5  A2      B1      B2      C           -6.9     6.9       0.0
+   6 │     6  A1      A2      B1      D            0.0     2.699    -2.699
+   7 │     7  A1      A2      B2      D            0.0     2.699    -2.699
+   8 │     8  A1      B1      B2      D           -6.9     6.9       0.0
+   9 │     9  A2      B1      B2      D           -6.9     6.9       0.0
+  10 │    10  A1      A2      C       D            0.0    -3.176     3.176
+  11 │    11  A1      B1      C       D            0.0    -5.875     5.875
+  12 │    12  A2      B1      C       D            0.0    -5.875     5.875
+  13 │    13  A1      B2      C       D            0.0    -5.875     5.875
+  14 │    14  A2      B2      C       D            0.0    -5.875     5.875
+  15 │    15  B1      B2      C       D            0.0   -12.775    12.775
 ```
 """
 function expectedf4table(

--- a/src/expectedfstat.jl
+++ b/src/expectedfstat.jl
@@ -1,0 +1,24 @@
+function expectedf2matrix!(
+    net::HybridNetwork;
+    keepinternal::Bool=false,
+    checkpreorder::Bool=true,
+)
+    m = descendenceweight(net; checkpreorder=checkpreorder)
+    P = m.V # also m[:tips]
+    #= idea: f2[i,j] = Ω[i,i] + Ω[j,j] -2 Ω[i,j] where
+    Ω = m[:tips] * Diagonal(edgelengths) * transpose(m[:tips])
+    is a linear function of edge lengths.
+    express: f2[i,j] = (nn × nn × ne) edgeweight array * edgelength vector
+    =#
+    nn,ne = size(P) # number of nodes, number of edges
+    edgeweight = zeros(eltype(P), nn,nn,ne)
+    # todo: calculate these weights
+    f2mat = zeros(eltype(P), nn,nn)
+    for e in net.edge
+        f2mat .+= e.length .* edgeweight[:,:,e.number]
+    end
+    return f2mat
+end
+
+# similarly: f3[x;i,j] = Ω[x,x] + Ω[i,j] - Ω[x,i] -2 Ω[x,j]
+# and f4[i1,i2; i3,i4] =

--- a/src/expectedfstat.jl
+++ b/src/expectedfstat.jl
@@ -62,5 +62,94 @@ function expectedf2matrix(
     return f2mat
 end
 
-# similarly: f3[x;i,j] = Ω[x,x] + Ω[i,j] - Ω[x,i] -2 Ω[x,j]
-# and f4[i1,i2; i3,i4] =
+"""
+    expectedf4table(net::HybridNetwork;
+                    showprogressbar::Bool=true,
+                    checkpreorder::Bool=true)
+
+Calculate the f4 statistics expected from `net`. Output: `(q,t)` where
+`t` is a list of taxa and `q` is a list of 4-taxon set objects of type
+[`PhyloNetworks.QuartetT{datatype}`](@ref).
+In each element of `q`, `taxonnumber` gives the indices in `taxa` of the 4 taxa
+of interest; and `data` contains the 3 primary expected f4-statistics, for the
+following 3 ordering of the 4 taxa:
+`t1,t2|t3,t4`, `t1,t3|t2,t4` and `t1,t4|t2,t3`.
+This output is similar to that of `PhyloNetworks.countquartetsintrees`,
+with 4-taxon sets listed in the same order
+(same output `t`, then same order of 4-taxon sets in `q`).
+
+For background of f-statistics, see for example
+[Lipson 2020](https://doi.org/10.1111/1755-0998.13230).
+f4-statistics are linear combination of f2-statistics:
+
+`f4[t1,t2|t3,t4] = (f2[t1,t4] + f2[t2,t3] - f2[t1,t3] - f2[t2,t4])/2`
+
+Given a set of 4 taxa, there are 12 ways to order them, but there are only
+2 "degrees of freedom" in the associated 12 f4-statistics, thanks to symmetries:
+* f4[t2,t1|t3,t4] = - f4[t1,t2|t3,t4]
+* f4[t3,t4|t1,t2] =   f4[t1,t2|t3,t4]
+* f4[t1,t2|t3,t4] + f4[t1,t3|t2,t4] + f4[t1,t4|t2,t3] = 0
+
+# example
+
+The first example is a tree: on which some f4 values are expected to be 0.
+
+Next, we use a network with 2 reticulations, which contains a "32 cycle".
+
+```jldoctest
+julia> net = readTopology("(D:1,((C:1,#H25:0):0.1,((((B1:10,B2:1):1.5,#H1:0):10.8,((A1:1,A2:1):0.001)#H1:0::0.5):0.5)#H25:0::0.501):1);");
+
+julia> # using PhyloPlots; plot(net, showedgelength=true);
+
+julia> q,t = expectedf4table(net);
+```
+"""
+function expectedf4table(
+    net::HybridNetwork;
+    showprogressbar::Bool=true,
+    checkpreorder::Bool=true
+)
+    f2mat = expectedf2matrix(net; checkpreorder=checkpreorder)
+    # f4s are linear combinations of edge lengths: from f2s, or from
+    # f4[i1,i2; i3,i4] = Ω[i1,i3] + Ω[i2,i4] - Ω[i1,i4] - Ω[i2,i3]
+    taxa = sort!(tipLabels(net))
+    # todo: also get permutation to sort
+    taxonnumber = Dict(taxa[i] => i for i in eachindex(taxa))
+    ntax = length(taxa)
+    nCk = nchoose1234(ntax) # matrix to rank 4-taxon sets
+    qtype = MVector{3,Float64} # 3 floats: f4_12_34, f4_13_24, f4_14_23
+    numq = nCk[ntax+1,4]
+    quartet = Vector{QuartetT{qtype}}(undef, numq)
+    ts = [1,2,3,4]
+    for qi in 1:numq
+        quartet[qi] = QuartetT(qi, SVector{4}(ts), MVector(0.,0.,0.))
+        # next: find the 4-taxon set with the next rank,
+        #       faster than using the direct mapping function
+        ind = findfirst(x -> x>1, diff(ts))
+        if ind === nothing ind = 4; end
+        ts[ind] += 1
+        for j in 1:(ind-1)
+            ts[j] = j
+        end
+    end
+    if showprogressbar
+        nstars = (numq < 50 ? numq : 50)
+        nquarnets_perstar = (numq/nstars)
+        println("Calculation of expected f4 statistics for $numq quartets...")
+        print("0+" * "-"^nstars * "+100%\n  ")
+        stars = 0
+        nextstar = Integer(ceil(nquarnets_perstar))
+    end
+    for qi in 1:numq
+        # todo: modify quartet[qi] with its 3 f4 statistics
+        if showprogressbar && qi >= nextstar
+            print("*")
+            stars += 1
+            nextstar = Integer(ceil((stars+1) * nquarnets_perstar))
+        end
+    end
+    showprogressbar && print("\n")
+    return quartet, taxa
+end
+
+# similarly: f3[x;i,j] = Ω[x,x] + Ω[i,j] - Ω[x,i] - Ω[x,j]

--- a/src/expectedfstat.jl
+++ b/src/expectedfstat.jl
@@ -1,6 +1,38 @@
+"""
+    expectedf2matrix(net::HybridNetwork; checkpreorder::Bool=true)
+
+Matrix of f2 statistics expected from `net`. The rows and columns
+correspond to the taxa in the network, in the same order as listed
+by `tiplabels(net)`.
+
+See for example [Lipson 2020](https://doi.org/10.1111/1755-0998.13230).
+
+# example
+
+```jldoctest
+julia> net2 = readnewick("(O:5.5,(((E:1.5)#H1:2.5::0.7,((#H1:0,D:1.5):1.5,((C:1,B:1):1)#H2:1::0.6):1.0):1.0,(#H2:0,A:2):3):0.5);");
+
+julia> f2 = PhyloNetworks.expectedf2matrix(net2)
+6×6 Matrix{Float64}:
+  0.0   9.95  11.0   9.56  9.56  11.0
+  9.95  0.0    5.45  5.95  5.95   8.95
+ 11.0   5.45   0.0   6.16  6.16  10.0
+  9.56  5.95   6.16  0.0   2.0    6.16
+  9.56  5.95   6.16  2.0   0.0    6.16
+ 11.0   8.95  10.0   6.16  6.16   0.0
+
+julia> tiplabels(net2) # order of taxa in rows and columns of f2 matrix above
+6-element Vector{String}:
+ "O"
+ "E"
+ "D"
+ "C"
+ "B"
+ "A"
+```
+"""
 function expectedf2matrix(
     net::HybridNetwork;
-    keepinternal::Bool=false,
     checkpreorder::Bool=true,
 )
     m = descendenceweight(net; checkpreorder=checkpreorder)

--- a/src/expectedfstat.jl
+++ b/src/expectedfstat.jl
@@ -9,15 +9,24 @@ function expectedf2matrix!(
     Ω = m[:tips] * Diagonal(edgelengths) * transpose(m[:tips])
     is a linear function of edge lengths.
     express: f2[i,j] = (nn × nn × ne) edgeweight array * edgelength vector
+    edgeweight[i,j,e] = (m[i,e] - m[j,e])^2
     =#
     nn,ne = size(P) # number of nodes, number of edges
     edgeweight = zeros(eltype(P), nn,nn,ne)
-    # todo: calculate these weights
+    for (I, p_ik) in pairs(P)
+        i = I[1]; k = I[2] # k = index of edge e, also edge number
+        for j in 1:(i-1)
+            w = (P[j,k] - p_ik)^2
+            edgeweight[j,i,k] = w
+            edgeweight[i,j,k] = w
+        end
+    end
     f2mat = zeros(eltype(P), nn,nn)
     for e in net.edge
         f2mat .+= e.length .* edgeweight[:,:,e.number]
     end
-    return f2mat
+    M = MatrixTopologicalOrder(f2mat, net, :b) # nodes in both columns & rows
+    return M
 end
 
 # similarly: f3[x;i,j] = Ω[x,x] + Ω[i,j] - Ω[x,i] -2 Ω[x,j]

--- a/src/expectedfstat.jl
+++ b/src/expectedfstat.jl
@@ -4,7 +4,8 @@ function expectedf2matrix!(
     checkpreorder::Bool=true,
 )
     m = descendenceweight(net; checkpreorder=checkpreorder)
-    P = m.V # also m[:tips]
+    P = m[:tips]
+    # change to :all to return a MatrixTopologicalOrder instead
     #= idea: f2[i,j] = Ω[i,i] + Ω[j,j] -2 Ω[i,j] where
     Ω = m[:tips] * Diagonal(edgelengths) * transpose(m[:tips])
     is a linear function of edge lengths.
@@ -25,8 +26,8 @@ function expectedf2matrix!(
     for e in net.edge
         f2mat .+= e.length .* edgeweight[:,:,e.number]
     end
-    M = MatrixTopologicalOrder(f2mat, net, :b) # nodes in both columns & rows
-    return M
+    # M = MatrixTopologicalOrder(f2mat, net, :b) # nodes in both columns & rows
+    return f2mat
 end
 
 # similarly: f3[x;i,j] = Ω[x,x] + Ω[i,j] - Ω[x,i] -2 Ω[x,j]

--- a/src/expectedfstat.jl
+++ b/src/expectedfstat.jl
@@ -1,18 +1,24 @@
 """
     expectedf2matrix(net::HybridNetwork; checkpreorder::Bool=true)
 
-Matrix of f2 statistics expected from `net`. The rows and columns
-correspond to the taxa in the network, in the same order as listed
-by `tiplabels(net)`.
+Matrix of f2 statistics expected from `net`, assuming that branch lengths in
+`net` represent "f2 distance". When data are based on allele frequencies,
+edge lengths measure drift units scaled by a variance factor p(1-p) depending
+on the allele frequency p at the root.
 
-See for example [Lipson 2020](https://doi.org/10.1111/1755-0998.13230).
+The rows and columns correspond to the taxa in the network, in the same order
+as listed by `tiplabels(net)`.
+
+For background on f-statistics, see for example
+[Patterson et al. 2012](https://doi.org/10.1534/genetics.112.145037) or
+[Lipson 2020](https://doi.org/10.1111/1755-0998.13230).
 
 # example
 
 ```jldoctest
 julia> net2 = readnewick("(O:5.5,(((E:1.5)#H1:2.5::0.7,((#H1:0,D:1.5):1.5,((C:1,B:1):1)#H2:1::0.6):1.0):1.0,(#H2:0,A:2):3):0.5);");
 
-julia> f2 = PhyloNetworks.expectedf2matrix(net2)
+julia> f2 = expectedf2matrix(net2)
 6×6 Matrix{Float64}:
   0.0   9.95  11.0   9.56  9.56  11.0
   9.95  0.0    5.45  5.95  5.95   8.95
@@ -67,21 +73,24 @@ end
                     showprogressbar::Bool=true,
                     checkpreorder::Bool=true)
 
-Calculate the f4 statistics expected from `net`. Output: `(q,t)` where
-`t` is a list of taxa and `q` is a list of 4-taxon set objects of type
-[`PhyloNetworks.QuartetT{datatype}`](@ref).
+Calculate the f4 statistics expected from `net`, assuming that branch lengths in
+`net` represent "f2 distance".
+Output: `(q,t)` where `t` is a list of taxa and `q` is a list of 4-taxon set
+objects of type [`PhyloNetworks.QuartetT{datatype}`](@ref).
 In each element of `q`, `taxonnumber` gives the indices in `taxa` of the 4 taxa
 of interest; and `data` contains the 3 primary expected f4-statistics,
 for the following 3 ordering of the 4 taxa:
 
     t1,t2|t3,t4   t1,t3|t4,t2   t1,t4|t2,t3.
 
-This output is similar to that of `PhyloNetworks.countquartetsintrees`,
-with 4-taxon sets listed in the same order
+This output is similar to that of [`countquartetsintrees`](@ref),
+with 4-taxon sets listed in the same alphabetical order
 (same output `t`, then same order of 4-taxon sets in `q`).
 
-For background of f-statistics, see for example
+For background on f-statistics, see for example
+[Patterson et al. 2012](https://doi.org/10.1534/genetics.112.145037) and
 [Lipson 2020](https://doi.org/10.1111/1755-0998.13230).
+
 f4-statistics are linear combination of f2-statistics:
 
 `f4[t1,t2|t3,t4] = (f2[t1,t4] + f2[t2,t3] - f2[t1,t3] - f2[t2,t4])/2`
@@ -96,11 +105,11 @@ Given a set of 4 taxa, there are 12 ways to order them, but there are only
 
 The first example is a tree: on which some f4 values are expected to be 0.
 ```jldoctest
-julia> net0 = readTopology("((D:0.6,((a1:.1,a2:.1):0.1,B:0.2):0.3),C:0.4);");
+julia> net0 = readnewick("((D:0.6,((a1:.1,a2:.1):0.1,B:0.2):0.3),C:0.4);");
 
 julia> # using PhyloPlots; plot(net0, showedgelength=true);
 
-julia> f4,t = PhyloNetworks.expectedf4table(net0);
+julia> f4,t = expectedf4table(net0);
 Calculation of expected f4 for 5 4-taxon sets...
 0+-----+100%
   *****
@@ -126,15 +135,17 @@ Next, we use a network with 2 reticulations, each time between sister species
 (resulting in 3-cycle blobs).
 
 ```jldoctest
-julia> net = readTopology("(D:1,((C:1,#H25:0):0.1,((((B1:10,B2:1):1.5,#H1:0):10.8,((A1:1,A2:1):0.001)#H1:0::0.5):0.5)#H25:0::0.501):1);");
+julia> net = readnewick("(D:1,((C:1,#H25:0):0.1,
+        ((((B1:10,B2:1):1.5,#H1:0):10.8,
+        ((A1:1,A2:1):0.001)#H1:0::0.5):0.5)#H25:0::0.501):1);");
 
 julia> # plot(net, showedgelength=true);
 
-julia> f4,t = PhyloNetworks.expectedf4table(net, showprogressbar=false);
+julia> f4,t = expectedf4table(net, showprogressbar=false);
 
 julia> using DataFrames
 
-julia> df = PhyloNetworks.tablequartetdata(f4, t; prefix="f4_") |> DataFrame
+julia> df = tablequartetdata(f4, t; prefix="f4_") |> DataFrame
 15×8 DataFrame
  Row │ qind   t1      t2      t3      t4      f4_12_34  f4_13_24  f4_14_23 
      │ Int64  String  String  String  String  Float64   Float64   Float64  

--- a/src/expectedfstat.jl
+++ b/src/expectedfstat.jl
@@ -1,4 +1,4 @@
-function expectedf2matrix!(
+function expectedf2matrix(
     net::HybridNetwork;
     keepinternal::Bool=false,
     checkpreorder::Bool=true,

--- a/src/pairwiseDistanceLS.jl
+++ b/src/pairwiseDistanceLS.jl
@@ -584,7 +584,7 @@ Traits and weights:
 - `trait[i]` is for leaf with `node.number = i` in `net`, and
   `trait[i][j] = k` means that leaf number `i` has state index `k` for trait `j`.
   These indices are those used in a substitution model
-  by [PhyloTraits](@extref PhyloTraits)):
+  by [PhyloTraits](https://juliaphylo.github.io/PhyloTraits.jl/stable/man/simulate_discrete/#Discrete-trait-simulation):
   kth value of `PhyloTraits.getlabels(model)`.
 - `siteweight[k]` gives the weight of site (or site pattern) `k` (default: all 1s).
 

--- a/src/pairwiseDistanceLS.jl
+++ b/src/pairwiseDistanceLS.jl
@@ -463,9 +463,113 @@ function calibratefrompairwisedistances!(
 end
 
 """
+    hammingdistancematrix(
+        trait::AbstractVector{Vector{Union{Missings.Missing,Int}}},
+        traitweight::AbstractVector{<:Real}=ones(length(trait[1]));
+        scaled::Bool=true
+    )
+
+Matrix of pairwise Hamming distances between taxa:
+proportion (or number) of traits at which 2 taxa differ, possibly weighted.
+
+Arguments:
+- `trait`: vector of vectors of integers.
+  `trait[i]` has the data for taxon number `i`. All vectors `trait[i]` should
+  be of the same length: same number of traits across taxa.
+  `trait[i][j] = k` means that taxon `i` has state index `k` for trait `j`.
+- `traitweight[k]` gives the weight of trait `k` (default: all 1s)
+- `scaled`: if `false`, the output distance is the number (or total weight) of
+  traits at which 2 taxa differ. If `scaled` is `true`, the output distance is
+  a proportion: the un-scaled distance divided by the number of traits
+  (or sum of trait weights).
+
+Missing data:
+For each pair, the Hamming distances is calculated ignoring any trait in
+which one of 2 values is missing. The total number of differences is then
+divided by the total weight of all sites, ignoring that some of them may
+have been missing for the pair. This is an inexact rescaling of the
+Hamming distance, assuming a small proportion of missing values for each pair.
+"""
+function hammingdistancematrix(
+    trait::AbstractVector{Vector{T}},
+    traitweight::AbstractVector{<:Real}=ones(length(trait[1]));
+    scaled::Bool=true
+) where T
+    ntax = length(trait)
+    M = zeros(Float64, ntax, ntax)
+    ncols = length(trait[1])
+    all(length.(trait) .== ncols) ||
+        error("all taxa should have the same number of traits")
+    length(traitweight) == ncols ||
+        error("$(length(traitweight)) weights but $ncols columns (traits) in the data")
+    # count pairwise differences, then multiply by pattern weight
+    for i in 2:ntax
+        species1 = trait[i]
+        for j in 1:(i-1)
+            species2 = trait[j]
+            for col in 1:ncols
+                if !(ismissing(species1[col]) || ismissing(species2[col])) &&
+                    (species1[col] != species2[col])
+                    M[i, j] += traitweight[col]
+                end
+            end
+            M[j,i] = M[i,j]
+        end
+    end
+    if scaled # normalize to get proportion
+        M ./= sum(traitweight)
+    end
+    return M
+end
+
+"""
+    distancecorrection_JC!(M::AbstractMatrix, nstates::Integer; scalar=1.01)
+
+Jukes-Cantor (JC) corrected distance matrix, to estimate pairwise evolutionary
+distances from scaled Hamming distances (proportion of sites at which the pair
+differs). `M` should contain non-negative values, such as Hamming distances
+from [`hammingdistancematrix`](@ref).
+The JC correction is defined as:
+`- 0.75 log(1 - M/0.75)` if there are 4 states, and more generally
+`- dmax log(1 - M/dmax)` where `dmax = (n-1/n)` on `n` states.
+
+Theoretically, scaled Hamming distances from the Jukes-Cantor model are < 0.75
+on four states, or < `(n-1)/n` on `n` states.
+
+If `M` has some values ≥ 0.75 (or `dmax` more generally), then `M` does not fit
+the Jukes-Cantor model, and `log(1 - M/0.75)` would give negative values.
+To avoid negative corrected distances, and numerical issues if some M values
+are close to 0.75, the JC correction here applies a following stronger
+normalization. `M` is modified in place to contain:
+
+`d_JC = - 0.75 log(1 - M/max{0.75, m*1.01})`
+
+for 4 states (replace 0.75 by (n-1)/n for n states),
+where `m` is the maximum observed distance in `M`.
+
+The `scalar=1.01` value above is a keyword argument, to adjust the strength
+of normalization.
+"""
+function distancecorrection_JC!(
+    M::AbstractMatrix,
+    nstates::Integer;
+    scalar::Real=1.01
+)
+    maxdist = (nstates-1)/nstates
+    M ./= max(maxdist, maximum(M)*scalar) # values ≤ 0.9901: log(1-M) well defined
+    M .= - maxdist .* log.( 1.0 .- M)     # 0 -> -0, not nice
+    for I in eachindex(M)
+        if M[I] == -0
+            M[I] = 0
+        end
+    end
+    return M
+end
+
+"""
     startingBL!(net::HybridNetwork,
                 trait::AbstractVector{Vector{Union{Missings.Missing,Int}}},
-                siteweight::AbstractVector{Float64}=ones(length(trait[1])))
+                siteweight::AbstractVector{<:Real}=ones(length(trait[1])))
 
 Calibrate branch lengths in `net` by minimizing the mean squared error
 between the JC-adjusted pairwise distance between taxa, and network-predicted
@@ -473,63 +577,33 @@ pairwise distances, using [`calibratefrompairwisedistances!`](@ref).
 The network is *not* forced to be time-consistent nor ultrametric.
 To avoid one source of non-identifiability, the network is "zipped" by
 forcing minor hybrid edges to have length 0.
+Finally, any edge length smaller than 1.0e-10 is reset to 0.0001,
+to avoid the 0 boundary.
 
-`siteweight[k]` gives the weight of site (or site pattern) `k` (default: all 1s).
-
-Assumptions:
-
-- all species have the same number of traits (sites): `length(trait[i])` constant
+Traits and weights:
 - `trait[i]` is for leaf with `node.number = i` in `net`, and
   `trait[i][j] = k` means that leaf number `i` has state index `k` for trait `j`.
-  These indices are those used in a substitution model (see `PhyloTraits.jl`):
-  kth value of `getlabels(model)`.
+  These indices are those used in a substitution model
+  by [PhyloTraits](@extref PhyloTraits)):
+  kth value of `PhyloTraits.getlabels(model)`.
+- `siteweight[k]` gives the weight of site (or site pattern) `k` (default: all 1s).
 
-Other:
-- Hamming distances are calculated for each pair, ignoring any site in which
-  one of 2 values is missing. The total number of differences is then divided
-  by the total weight of all sites, ignoring that some of them may have been
-  missing for the pair. This is an inexact rescaling of the hamming distance,
-  assuming a small proportion of missing values for each pair.
-- Theoretically, Hamming distances are < 0.75 with four states,
-  or < (n-1)/n for n states.
-  If not, all pairwise hamming distances are scaled by `.75/(m*1.01)` where `m`
-  is the maximum observed hamming distance, to make them all < 0.75.
-  The JC correction calculates: d_JC = - 0.75 log(1-d_hamming/0.75) for n=4 states
-- At the end, any edge length smaller than 1.0e-10 is reset to 0.0001,
-  to avoid the 0 boundary.
+See [`hammingdistancematrix`](@ref) for how missing data are treated to
+calculate the Hamming distance.  
+See [`distancecorrection_JC!`](@ref) for the Jukes-Cantor correction.
+For this correction, the number of traits is taken as the maximum trait
+state index (denoted `k` above).
 """
 function startingBL!(
     net::HybridNetwork,
     trait::AbstractVector{Vector{Union{Missings.Missing,Int}}},
     siteweight::AbstractVector{<:Real}=ones(Float64,length(trait[1]))
 )
-    nspecies = net.numtaxa
-    M = zeros(Float64, nspecies, nspecies) # pairwise distances initialized to 0
-    # count pairwise differences, then multiply by pattern weight
-    ncols = length(trait[1]) # assumption: all species have same # columns
-    length(siteweight) == ncols ||
-      error("$(length(siteweight)) site weights but $ncols columns in the data")
-    for i in 2:nspecies
-        species1 = trait[i]
-        for j in 1:(i-1)
-            species2 = trait[j]
-            for col in 1:ncols
-                if !(ismissing(species1[col]) || ismissing(species2[col])) &&
-                    (species1[col] != species2[col])
-                    M[i, j] += siteweight[col]
-                end
-            end
-            M[j,i] = M[i,j]
-        end
-    end
-    Mp = M ./ sum(siteweight) # to get proportion of sites, for each pair
-
-    # estimate pairwise evolutionary distances using extended Jukes Cantor model
+    dhat = hammingdistancematrix(trait, siteweight)
+    net.numtaxa == size(dhat,1) ||
+        error("$(net.numtaxa) in net, yet $(join(size(dhat),"×")) distances")
     nstates = mapreduce(x -> maximum(skipmissing(x)), max, trait)
-    maxdist = (nstates-1)/nstates
-    Mp[:] = Mp ./ max(maxdist, maximum(Mp*1.01)) # values in [0,0.9901]: log(1-Mp) well defined
-    dhat = - maxdist .* log.( 1.0 .- Mp)
-
+    distancecorrection_JC!(dhat, nstates) # default scalar=1.01
     taxonnames = [net.leaf[i].name for i in sortperm([n.number for n in net.leaf])]
     # taxon names: to tell the calibration that row i of dhat is for taxonnames[i]
     # trait[i][j] = trait j for taxon at node number i: 'node.number' = i

--- a/src/quartets.jl
+++ b/src/quartets.jl
@@ -68,35 +68,15 @@ end
 
 Convert a vector of [`QuartetT`](@ref) objects to a table with 1 row for
 each four-taxon set in the list. Each four-taxon set contains quartet data of
-some type `T`, which determines the number of columns in the table.
-This data type `T` should be a vector of length 3 or 4, or a 3×n matrix.
+some type (vector of length 3 or 4, or 3×n matrix), which determines the
+number of columns in the table (3, 4, or 3n).
+[`tablequartetdata`](@ref) is called with prefix "CF",
+to name the first 3 columns "CF12_34", "CF13_24", "CF14_23" --- unless the
+full list of column names is provided in `colnames`.
+
 The output is a `NamedTuple`, to which we can apply common table operations
 as a [`Table.jl`](https://github.com/JuliaData/Tables.jl)-compatible source.
-It can easily be converted to other table formats (e.g. these packages
-[integrate with Tables.jl](https://github.com/JuliaData/Tables.jl/blob/master/INTEGRATIONS.md))
-such as a `DataFrame`.
-
-In the output table, the columns are, in this order:
-- `qind`: contains the quartet's `number`
-- `t1, t2, t3, t4`: contain the quartet's `taxonnumber`s if no `taxonnames`
-  are given, or the taxon names otherwise. The name of taxon number `i` is
-  taken to be `taxonnames[i]`.
-- 3 or more columns for the quartet's `data`: see [`quartetdata_columnnames`](@ref).
-
-In short, the first 3 columns of data are named `CF12_34, CF13_24, CF14_23`.
-
-If quartets have 4 data entries, then the 4th column is named `ngenes`,
-and a quartet with a value `ngenes` of 0 is skipped (excluded) from the table,
-unless `keepQwithoutgenes=true` (which is the default: 4-taxon sets are kept
-by default even without any informative genes).
-
-If quartets have a data matrix with 3 rows and `d` columns, then the
-columns 4,5,6 in the table are named `V2_12_34, V2_13_24, V2_14_23`
-and contain the data in the second column of the quartet's data matrix.
-And so on.
-
-For the table to have non-default column names, provide the desired
-3, 4, or 3×d names as a vector via the optional argument `colnames`.
+It can easily be converted to other table formats such as a `DataFrame`.
 
 See [`countquartetsintrees`](@ref) for examples.
 """
@@ -131,7 +111,9 @@ In the output table, the columns are, in this order:
   taken to be `taxonnames[i]`.
 - 3 or more columns for the quartet's `data`: see [`quartetdata_columnnames`](@ref).
 
-In short, the first 3 columns of data are named `12_34, 13_24, 14_23`.
+In short, the first 3 columns of data are named "12_34", "13_24", "14_23 by default.
+If a `prefix` is provided, this prefix is used for these first 3 column names,
+for example: "CF12_34", "CF13_24", "CF14_23" if `prefix="CF"`.
 
 If quartets have 4 data entries, then the 4th column is named `ngenes`,
 and a quartet with a value `ngenes` of 0 is skipped (excluded) from the table,
@@ -145,7 +127,10 @@ And so on.
 
 For the table to have non-default column names, provide the desired
 3, 4, or 3×d names as a vector via the optional argument `colnames`.
+This argument takes precedence over `prefix`, that is, a prefix is ignored if
+the full list of column names is given.
 
+Used by [`tablequartetCF`](@ref) with prefix "CF".
 See [`countquartetsintrees`](@ref) for examples.
 """
 function tablequartetdata(

--- a/src/recursion_matrices.jl
+++ b/src/recursion_matrices.jl
@@ -351,7 +351,7 @@ path weights from each *node* to any other node.
 ```jldoctest descendenceweight
 julia> net = readnewick("((t4:1.5,((t3:1.27,t1:1.27):1.06,#H8:0.0::0.4):1.18):1.16,(t2:1.32)#H8:1.34::0.6);");
 
-julia> m = descendenceweight(net);
+julia> m = PhyloNetworks.descendenceweight(net);
 
 julia> m[:tips]
 4×9 Matrix{Float64}:

--- a/src/recursion_matrices.jl
+++ b/src/recursion_matrices.jl
@@ -95,6 +95,8 @@ function Base.getindex(
     indtips::Vector{Int}=collect(1:length(obj.tipnumbers)),
     nonmissing::BitVector=trues(length(obj.tipnumbers))
 )
+    d == :all && return obj.V
+    # otherwise, do extra work
     tipnums = obj.tipnumbers[indtips][nonmissing]
     maskTips = indexin(tipnums, obj.nodenumbers_toporder)
     if d == :tips # Extract rows and/or columns corresponding to the tips with data
@@ -122,7 +124,6 @@ function Base.getindex(
         obj.indexation == :r && error("""Both rows and columns must be net
                                        ordered to take the submatrix tips vs internal nodes.""")
     end
-    d == :all && return obj.V
 end
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -306,7 +306,7 @@ Base.showerror(io::IO, e::RootMismatch) = print(io, "RootMismatch: ", e.msg);
 abstract type AQuartet end
 
 """
-QuartetT{T}
+    QuartetT{T}
 
 Generic type for 4-taxon sets. Fields:
 - `number`: rank of the 4-taxon set

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using PhyloNetworks
 using CSV # for reading files
 using DataFrames
 using Distributed # for parsimony search, currently broken
-using LinearAlgebra: diag # LinearAlgebra.rotate! not brought into scope
+using LinearAlgebra: diag, Diagonal # LinearAlgebra.rotate! not brought into scope
 using Random
 using StableRNGs
 
@@ -21,6 +21,7 @@ tests = [
     "test_parsimony.jl", # has broken tests: parsimony search broken
     "test_recursion_matrices.jl",
     "test_calibratePairwise.jl",
+    "test_expectedfstat.jl",
     "test_relaxed_reading.jl",
     "test_isMajor.jl",
     "test_interop.jl",

--- a/test/test_auxiliary.jl
+++ b/test/test_auxiliary.jl
@@ -85,6 +85,13 @@ PhyloNetworks.setmultiplegammas!([net.edge[18]], [0.25])
 
 @test PhyloNetworks.getlengths([net.edge[1]]) == [net.edge[1].length]
 @test PhyloNetworks.getlengths([net.edge[1], net.edge[5]]) == [net.edge[1].length, net.edge[5].length]
+
+net = readnewick("(((a1)#H1,#H2),(#H1,(a2)#H2));")
+@test_throws "edge(s) number 2,3,5,7 have no" PhyloNetworks.check_valid_gammas(net)
+for (i,γ) in zip([2,3,5,7], [.6,.3,-.1,.6]) net.edge[i].gamma = γ; end
+@test_throws "edge(s) number 5 have negative" PhyloNetworks.check_valid_gammas(net)
+net.edge[5].gamma = 0.4
+@test_throws "hybrid node number 3 has total" PhyloNetworks.check_valid_gammas(net)
 end
 
 @testset "hashybridladder, istreechild, isgalled" begin

--- a/test/test_expectedfstat.jl
+++ b/test/test_expectedfstat.jl
@@ -5,7 +5,7 @@
 # has a degree-2 node
 nwk = "((((a1:0.24)#H2:0.58::0.7,(((#H2:0.62):0.49,(a21:0.14,a22:0.86):0.51):0.29)#H1:0.19::0.6):0.88,(#H1:0.82,a3:0.89):0.33):0.17,((#H3:0.67,((b1:0.87)#H3:0.86::0.8,b2:0.42):0.69):0.18,b3:0.66):0.43);"
 net = readnewick(nwk)
-f2 = PhyloNetworks.expectedf2matrix(net)
+f2 = expectedf2matrix(net)
 #= manual calculations:
 m = PhyloNetworks.descendenceweight(net)[:tips]
 Ω = m * Diagonal([e.length for e in net.edge]) * transpose(m) # covariance

--- a/test/test_expectedfstat.jl
+++ b/test/test_expectedfstat.jl
@@ -1,0 +1,29 @@
+@testset "expected f-stat" begin
+
+# 7 tips, 2 blobs: a 3-cycle (h=1) and a 4-blob (h=2) not galled
+# rooted, 4 non-external cut edges (3 when semidirected)
+# has a degree-2 node
+nwk = "((((a1:0.24)#H2:0.58::0.7,(((#H2:0.62):0.49,(a21:0.14,a22:0.86):0.51):0.29)#H1:0.19::0.6):0.88,(#H1:0.82,a3:0.89):0.33):0.17,((#H3:0.67,((b1:0.87)#H3:0.86::0.8,b2:0.42):0.69):0.18,b3:0.66):0.43);"
+net = readnewick(nwk)
+f2 = PhyloNetworks.expectedf2matrix!(net)
+#= manual calculations:
+m = PhyloNetworks.descendenceweight(net)[:tips]
+Ω = m * Diagonal([e.length for e in net.edge]) * transpose(m) # covariance
+@test Matrix(vcv(net)) ≈ Ω
+f2m = -2Ω
+for i in 1:7, j in 1:7
+    f2m[i,j] += Ω[i,i] + Ω[j,j]
+end
+=#
+f2m = [
+0.0      1.608868 2.328868 2.495188 4.023188 3.244388 2.614388;
+1.608868 0.0      1.0      2.4652   4.178    3.3992   2.7692;
+2.328868 1.0      0.0      3.1852   4.898    4.1192   3.4892;
+2.495188 2.4652   3.1852   0.0      3.8888   3.11     2.48;
+4.023188 4.178    4.898    3.8888   0.0      1.8948   2.7288;
+3.244388 3.3992   4.1192   3.11     1.8948   0.0      1.95;
+2.614388 2.7692   3.4892   2.48     2.7288   1.95     0.0
+]
+@test f2 ≈ f2m
+
+end

--- a/test/test_expectedfstat.jl
+++ b/test/test_expectedfstat.jl
@@ -5,7 +5,7 @@
 # has a degree-2 node
 nwk = "((((a1:0.24)#H2:0.58::0.7,(((#H2:0.62):0.49,(a21:0.14,a22:0.86):0.51):0.29)#H1:0.19::0.6):0.88,(#H1:0.82,a3:0.89):0.33):0.17,((#H3:0.67,((b1:0.87)#H3:0.86::0.8,b2:0.42):0.69):0.18,b3:0.66):0.43);"
 net = readnewick(nwk)
-f2 = PhyloNetworks.expectedf2matrix!(net)
+f2 = PhyloNetworks.expectedf2matrix(net)
 #= manual calculations:
 m = PhyloNetworks.descendenceweight(net)[:tips]
 Ω = m * Diagonal([e.length for e in net.edge]) * transpose(m) # covariance

--- a/test/test_expectedfstat.jl
+++ b/test/test_expectedfstat.jl
@@ -1,4 +1,4 @@
-@testset "expected f-stat" begin
+@testset "expected f2, f3, f4" begin
 
 # 7 tips, 2 blobs: a 3-cycle (h=1) and a 4-blob (h=2) not galled
 # rooted, 4 non-external cut edges (3 when semidirected)
@@ -26,4 +26,35 @@ f2m = [
 ]
 @test f2 ≈ f2m
 
+@test_throws "reference taxon bx" PhyloNetworks.expectedf3matrix(net, "bx"; preorder=false)
+f3 = PhyloNetworks.expectedf3matrix(net, "b3"; preorder=false)
+@test f3 ≈ [
+0       1.88736 1.88736 1.2996 0.66  0.66  0
+1.88736 0       2.6292  1.392  0.66  0.66  0
+1.88736 2.6292  0       1.392  0.66  0.66  0
+1.2996  1.392   1.392   0      0.66  0.66  0
+0.66    0.66    0.66    0.66   0     1.392 0
+0.66    0.66    0.66    0.66   1.392 0     0
+0       0       0       0      0     0     0
+]
+
+originalstdout = stdout
+redirect_stdout(devnull) # to hide progress bar
+f4,t = expectedf4table(net, preorder=false)
+redirect_stdout(originalstdout)
+nt = tablequartetdata(f4, t; colnames="f4_" .* ["12_34", "13_42", "14_23"])
+# DataFrame(nt) # splits with a 0: aa|bb, ab3|b1b2, a21a22|xy
+@test keys(nt) == (:qind, :t1, :t2, :t3, :t4, :f4_12_34, :f4_13_42, :f4_14_23)
+@test nt[:f4_12_34] ≈ [-.64944,-.74184,-.0924,-.0924,0,-.74184,-0.0924,-.0924,
+  0,0,0,0,0,0,0,-.74184,-.0924,-.0924,
+  0,0,0,0,0,0,0,0,0,0,
+  0,0,0,           -.732,-.732,-.732,-.732]
+@test nt[:f4_13_42] ≈ [.64944,.74184,-.49536,-.49536,-1.2372,.74184,-.49536,-.49536,
+ -1.2372,-1.95936,-1.95936,-2.7012,-1.3716,-1.464,-1.464,.74184,-.49536,-.49536,
+ -1.2372,-1.22736,-1.22736,-1.9692,-.6396,-.732,-.732,-1.22736,-1.22736,-1.9692,
+ -.6396,-.732,-.732,.732, .732, .732, .732]
+@test nt[:f4_14_23] ≈ [0,0,.58776,.58776,1.2372,0,.58776,.58776,
+  1.2372, 1.95936, 1.95936, 2.7012, 1.3716, 1.464, 1.464,0,.58776,.58776,
+  1.2372, 1.22736, 1.22736, 1.9692, .6396, .732, .732, 1.22736, 1.22736, 1.9692,
+  .6396, .732, .732,0,0,0,0]
 end

--- a/test/test_recursion_matrices.jl
+++ b/test/test_recursion_matrices.jl
@@ -83,6 +83,20 @@ T2 =  [1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 
 @test T[:all] ≈ T2
 
+#------ descendence edge -> node -----
+P = PhyloNetworks.descendenceweight(net; checkpreorder=false)
+@test P[:all] == [
+ 0 0  0  0 0 0  0  0 0
+ 0 0  0  0 0 0  0  0 1
+ 0 0  0  0 0 0  0  1 1
+ 0 0  0  0 1 0  0  1 1
+ 0 0  0  1 0 0  0  0 1
+ 0 0 .4 .4 0 0 .6 .6 1
+ 0 0 .4 .4 0 1 .6 .6 1
+ 0 1  0  1 0 0  0  0 1
+ 1 0  0  0 0 0  0  0 0
+]
+
 ##################
 ## New formula
 #################


### PR DESCRIPTION
- new and exported:
  + `expectedf2matrix`, `expectedf4table`
  + `tablequartetdata`: code from `tablequartetCF`, which now calls `tablequartetdata(..., prefix="CF")`
- new but not exported:
  + `expectedf3matrix`, `check_valid_gammas`
  + `hammingdistancematrix` and `distancecorrection_JC!`, whose code was extracted from `startingBL!`
- new manual page to explain these f-statistics and previously available functions `pairwisetaxondistancematrix` and `countquartetsintrees`.

Problem to be discussed: For quartet concordance factors, there is more symmetry than for f4-statistics: CF(12|34) = CF(12|43), yet f4(12|34) = - f4(12|43). For this reason, the 3 f4s are listed for the following taxon orders: `12_34, 13_42, 14_23`, and then these 3 values sum up to 0.
Yet, the default column names used by `tablequartetCF` are: `12_34, 13_24, 14_23` (note `_24` instead of `_42` in the second).
* For backward-compatibility, we should keep these original column names for CFs.
* But for f4 statistics, it would be best to make them match the actual order of taxa in the f4 statistics by default, without relying on the user to provide their own names (as shown in the documentation).
I'm not sure what's the best way to do this.
